### PR TITLE
refactor parseExpression function

### DIFF
--- a/examples/list/listModule.json
+++ b/examples/list/listModule.json
@@ -24,11 +24,32 @@
         "traits": []
       },
       {
-        "id": "{{$moduleId}}1",
+        "id": "{{$moduleId}}text",
         "type": "core/v1/text",
         "properties": {
           "value": {
             "raw": "**{{value}}**",
+            "format": "md"
+          }
+        },
+        "traits": [
+          {
+            "type": "core/v1/slot",
+            "properties": {
+              "container": {
+                "id": "{{$moduleId}}hstack",
+                "slot": "content"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "id": "{{$moduleId}}inputValueText",
+        "type": "core/v1/text",
+        "properties": {
+          "value": {
+            "raw": "**{{ {{$moduleId}}input.value }}**",
             "format": "md"
           }
         },
@@ -174,7 +195,7 @@
                   "componentId": "$utils",
                   "method": {
                     "name": "alert",
-                    "parameters": "listen module vent：{{ littleItem1.value }}！"
+                    "parameters": "listen module event：{{ $listItem.name }}!"
                   },
                   "wait": {},
                   "disabled": false

--- a/packages/runtime/__tests__/expression.spec.ts
+++ b/packages/runtime/__tests__/expression.spec.ts
@@ -1,36 +1,109 @@
-import { StateManager } from '../src/services/stateStore';
+import { StateManager, parseExpression } from '../src/services/stateStore';
 
 describe('parseExpression function', () => {
-  const parseExpression = new StateManager().parseExpression;
   it('can parse {{}} expression', () => {
-    expect(parseExpression('{{ value }}')).toMatchObject([
-      { expression: 'value', isDynamic: true },
-    ]);
+    expect(parseExpression('value')).toMatchObject(['value']);
+    // wrong: {{{id: 123}}}. Must have space between {{ and {
+    expect(parseExpression('{{ {id: 123} }}')).toMatchObject([[' {id: 123} ']]);
     expect(parseExpression('Hello, {{ value }}!')).toMatchObject([
-      { expression: 'Hello, ', isDynamic: false },
-      { expression: 'value', isDynamic: true },
-      { expression: '!', isDynamic: false },
+      'Hello, ',
+      [' value '],
+      '!',
     ]);
-    expect(
-      parseExpression('{{ $listItem.name }} is in {{ root.listTitle }} list')
-    ).toMatchObject([
-      { expression: '{{$listItem.name}}', isDynamic: false },
-      { expression: ' is in ', isDynamic: false },
-      { expression: 'root.listTitle', isDynamic: true },
-      { expression: ' list', isDynamic: false },
-    ]);
-    expect(parseExpression('{{{{}}}}}}')).toMatchObject([
-      { expression: '{{', isDynamic: true },
-      { expression: '}}}}', isDynamic: false },
+
+    expect(parseExpression('{{input1.value}}')).toMatchObject([['input1.value']]);
+    expect(parseExpression('{{fetch.data}}')).toMatchObject([['fetch.data']]);
+
+    expect(parseExpression('{{{{}}}}')).toMatchObject([[[]]]);
+
+    expect(parseExpression('{{ value }}, {{ input1.value }}!')).toMatchObject([
+      [' value '],
+      ', ',
+      [' input1.value '],
+      '!',
     ]);
   });
 
   it('can parse $listItem expression', () => {
     expect(parseExpression('{{ $listItem.value }}')).toMatchObject([
-      { expression: '{{$listItem.value}}', isDynamic: false },
+      '{{ $listItem.value }}',
     ]);
     expect(parseExpression('{{ $listItem.value }}', true)).toMatchObject([
-      { expression: '$listItem.value', isDynamic: true },
+      [' $listItem.value '],
     ]);
+    expect(
+      parseExpression(
+        '{{ {{$listItem.value}}input.value + {{$moduleId}}fetch.value }}!',
+        true
+      )
+    ).toMatchObject([
+      [' ', ['$listItem.value'], 'input.value + ', ['$moduleId'], 'fetch.value '],
+      '!',
+    ]);
+  });
+});
+
+describe('evalExpression function', () => {
+  const scope = {
+    value: 'Hello',
+    input1: {
+      value: 'world',
+    },
+    fetch: {
+      data: [{ id: 1 }, { id: 2 }],
+    },
+    checkbox: {
+      value: true,
+    },
+    $listItem: {
+      value: 'foo',
+    },
+    $moduleId: 'moduleBar',
+    fooInput: {
+      value: 'Yes, ',
+    },
+    moduleBarFetch: {
+      value: 'ok',
+    },
+  };
+  const stateStore = new StateManager();
+  it('can eval {{}} expression', () => {
+    expect(stateStore.maskedEval('value', false, scope)).toEqual('value');
+    expect(stateStore.maskedEval('{{true}}', false, scope)).toEqual(true);
+    expect(stateStore.maskedEval('{{ false }}', false, scope)).toEqual(false);
+    expect(stateStore.maskedEval('{{[]}}', false, scope)).toEqual([]);
+    expect(stateStore.maskedEval('{{ [] }}', false, scope)).toEqual([]);
+    expect(stateStore.maskedEval('{{ [1,2,3] }}', false, scope)).toEqual([1, 2, 3]);
+
+    expect(stateStore.maskedEval('{{ {} }}', false, scope)).toEqual({});
+    expect(stateStore.maskedEval('{{ {id: 123} }}', false, scope)).toEqual({ id: 123 });
+    expect(stateStore.maskedEval('{{nothing}}', false, scope)).toEqual('{{ nothing }}');
+
+    expect(stateStore.maskedEval('{{input1.value}}', false, scope)).toEqual('world');
+    expect(stateStore.maskedEval('{{checkbox.value}}', false, scope)).toEqual(true);
+    expect(stateStore.maskedEval('{{fetch.data}}', false, scope)).toMatchObject([
+      { id: 1 },
+      { id: 2 },
+    ]);
+
+    expect(stateStore.maskedEval('{{{{}}}}', false, scope)).toEqual(undefined);
+
+    expect(
+      stateStore.maskedEval('{{ value }}, {{ input1.value }}!', false, scope)
+    ).toEqual('Hello, world!');
+  });
+
+  it('can eval $listItem expression', () => {
+    expect(stateStore.maskedEval('{{ $listItem.value }}', false, scope)).toEqual(
+      '{{ $listItem.value }}'
+    );
+    expect(stateStore.maskedEval('{{ $listItem.value }}', true, scope)).toEqual('foo');
+    expect(
+      stateStore.maskedEval(
+        '{{ {{$listItem.value}}Input.value + {{$moduleId}}Fetch.value }}!',
+        true,
+        scope
+      )
+    ).toEqual('Yes, ok!');
   });
 });

--- a/packages/runtime/src/App.tsx
+++ b/packages/runtime/src/App.tsx
@@ -5,6 +5,7 @@ import { ImplWrapper } from './services/ImplWrapper';
 import { resolveAppComponents } from './services/resolveAppComponents';
 import { AppProps, UIServices } from './types/RuntimeSchema';
 import { DebugEvent, DebugStore } from './services/DebugComponents';
+import { css } from '@emotion/react';
 
 // inject modules to App
 export function genApp(services: UIServices) {
@@ -38,7 +39,7 @@ export const App: React.FC<AppProps> = props => {
   );
 
   return (
-    <div className="App">
+    <div className="App" css={css`height: 100vh; overflow: auto`}>
       {topLevelComponents.map(c => {
         return (
           <ImplWrapper


### PR DESCRIPTION
This PR is about #113 , and helps module mechanism. 

English Version

# Expression Design

# Supported writing

`'{{ value }}'` '100'

`'{{ value.toUppercase() }}'`'ABC'

`'Hello, {{ value }}!'`'Hello, world'

`'{{ $listItem.name }} is {{ $listItem.age }} years old'`'Tom is 10 years old'

`'{{ $listItem.name }} is in {{ root.listTitle }} list'`'Tom is in UserList list'

# Nested expression

Expressions support nesting, which is useful in the context of lists and modules. E.g:

`'{{ {{$listItem.value}}Input.value + {{$moduleId}}Fetch.value }}!'`

The parser will step by step `eval` and concatenate strings from the inside to the outside.

# Some wrong usage

Note that in most cases, it is best to always add a space inside `{{` and `}}`, otherwise the parser will not be able to parse it normally. The following is the wrong way of writing:

`{{{}}}`

`{{{id: 1}}}` (change it to `{{ {id: 1} }}`

`{{ [1,2,3] }}string` (the result will be `'[Object Object]'`).

# Special keywords

`$i` `$listItem` and `$moduleId` are keywords, used in lists and modules.

# Error handling

When the an error happened during `eval`, the expression itself will be returned directly.

---

# Expression 设计

# 支持的写法

`'{{ value }}'` '100'

`'{{ value.toUppercase() }}'` 'ABC'

`'Hello, {{ value }}!'` 'Hello, world'

`'{{ $listItem.name }} is {{ $listItem.age }} years old'` 'Tom is 10 years old'

`'{{ $listItem.name }} is in {{ root.listTitle }} list'` 'Tom is in UserList list'

# 嵌套的表达式

表达式支持嵌套，这在列表和模块的场景下比较有用。例如：

`'{{ {{$listItem.value}}Input.value + {{$moduleId}}Fetch.value }}!'`

解析器将会按照从里到外的顺序逐级`eval` 和拼接字符串。

# 一些错误的用法

注意，大部分情况下最好总是在`{{`和`}}` 内侧加上一个空格，否则解析器将不能正常解析。下面是错误的写法：

`{{{}}}`

`{{{id: 1}}}` （改成`{{ {id: 1} }}`就可以了）

`{{ [1,2,3] }}string`（结果会是`'[Object Object]'` ）。

# 特殊关键字

`$i` `$listItem` 和 `$moduleId`是关键字，用在列表和模块中。

# 错误处理

当表达式无法`eval` 值或者`eval` 过程中报错时，会直接返回表达式本身。

