### PR TITLE
support unmount component when hidden

### DIFF
--- a/packages/runtime/src/services/ImplWrapper.tsx
+++ b/packages/runtime/src/services/ImplWrapper.tsx
@@ -129,6 +129,7 @@ export const ImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperProps>(
         {} as TraitResult['props']
       );
     }, [traitResults]);
+    const unmount = traitResults.some(r => r.unmount);
 
     // component properties
     const [evaledComponentProperties, setEvaledComponentProperties] = useState(() => {
@@ -150,7 +151,7 @@ export const ImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperProps>(
 
     const mergedProps = { ...evaledComponentProperties, ...propsFromTraits };
 
-    const C = (
+    const C = unmount ? null : (
       <Impl
         key={c.id}
         {...mergedProps}

--- a/packages/runtime/src/traits/core/hidden.tsx
+++ b/packages/runtime/src/traits/core/hidden.tsx
@@ -2,18 +2,29 @@ import { createTrait } from '@sunmao-ui/core';
 import { Static, Type } from '@sinclair/typebox';
 import { TraitImplementation } from 'src/types/RuntimeSchema';
 
-const useHiddenTrait: TraitImplementation<Static<typeof PropsSchema>> = ({ hidden }) => {
-  return {
-    props: {
-      customStyle: {
-        content: hidden ? 'display: none' : '',
+const useHiddenTrait: TraitImplementation<Static<typeof PropsSchema>> = ({
+  hidden,
+  visually,
+}) => {
+  if (visually) {
+    return {
+      props: {
+        customStyle: {
+          content: hidden ? 'display: none' : '',
+        },
       },
-    },
+    };
+  }
+
+  return {
+    props: {},
+    unmount: hidden,
   };
 };
 
 const PropsSchema = Type.Object({
   hidden: Type.Boolean(),
+  visually: Type.Boolean(),
 });
 
 export default {

--- a/packages/runtime/src/types/RuntimeSchema.ts
+++ b/packages/runtime/src/types/RuntimeSchema.ts
@@ -80,6 +80,7 @@ export type TraitResult = {
     callbackMap?: CallbackMap;
     effects?: Array<() => void>;
   } | null;
+  unmount?: boolean;
 };
 
 export type TraitImplementation<T = any> = (


### PR DESCRIPTION
Currently, we only support hidden a component visually, which is not good for performance and miss the control of the component life cycle.

In this PR, I've added a new prop to the hidden trait, which controls the hidden is visually or logically.

The short of this implementation is it could not re-use the `props` field in `TraitResult`, so I added a new field `unmount` to let the `ImplWrapper` know what to do. This makes the `TraitResult` type looks casual, any suggestion on the type will be appreciated. 