### PR TITLE
export internal components and allow call global method

### DIFF
--- a/packages/editor/src/main.tsx
+++ b/packages/editor/src/main.tsx
@@ -13,10 +13,16 @@ type Options = Partial<{
   components: Parameters<Registry['registerComponent']>[0][];
   traits: Parameters<Registry['registerTrait']>[0][];
   modules: Parameters<Registry['registerModule']>[0][];
+  container: Element;
 }>;
 
 export default function renderApp(options: Options = {}) {
-  const { components = [], traits = [], modules = [] } = options;
+  const {
+    components = [],
+    traits = [],
+    modules = [],
+    container = document.getElementById('root'),
+  } = options;
   components.forEach(c => registry.registerComponent(c));
   traits.forEach(t => registry.registerTrait(t));
   modules.forEach(m => registry.registerModule(m));
@@ -28,6 +34,6 @@ export default function renderApp(options: Options = {}) {
         <Editor App={App} registry={registry} stateStore={stateStore} />
       </ChakraProvider>
     </StrictMode>,
-    document.getElementById('root')
+    container
   );
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -28,3 +28,4 @@ export * from './types/RuntimeSchema';
 export * from './types/TraitPropertiesSchema';
 export * from './constants';
 export * from './services/registry';
+export { default as Slot } from './components/_internal/Slot';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -29,3 +29,4 @@ export * from './types/TraitPropertiesSchema';
 export * from './constants';
 export * from './services/registry';
 export { default as Slot } from './components/_internal/Slot';
+export { ModuleRenderer } from './components/_internal/ModuleRenderer';

--- a/packages/runtime/src/services/util-methods.ts
+++ b/packages/runtime/src/services/util-methods.ts
@@ -40,6 +40,12 @@ export function mountUtilMethods(apiService: ApiService) {
         default:
           break;
       }
+      if (name in window) {
+        const method = window[name as keyof Window];
+        if (typeof method === 'function') {
+          method(parameters);
+        }
+      }
     }
 
     if (componentId === '$module') {


### PR DESCRIPTION
1. Export Slot and ModuleRenderer which is useful for components developers.
2. Add a temporary way to call global methods.
3. Allow customize editor container.

The second part is a workaround. Currently, we allow inject dependencies to eval scope, but when users are using events trait, there is no way to these dependencies.
