### PR TITLE
manage editor styles in a single CSS

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -60,6 +60,8 @@
     "babel-jest": "^27.2.1",
     "eslint-plugin-react-hooks": "^4.3.0",
     "jest": "^27.2.1",
+    "postcss": "^8.4.5",
+    "postcss-import": "^14.0.2",
     "tsup": "^5.11.0",
     "typescript": "^4.5.0",
     "vite": "^2.6.13"

--- a/packages/editor/postcss.config.js
+++ b/packages/editor/postcss.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: [require('postcss-import')()],
+};

--- a/packages/editor/src/components/CodeEditor/CssEditor.tsx
+++ b/packages/editor/src/components/CodeEditor/CssEditor.tsx
@@ -5,9 +5,6 @@ import { css } from '@emotion/css';
 import 'codemirror/mode/css/css';
 import 'codemirror/addon/fold/brace-fold';
 import 'codemirror/addon/fold/foldgutter';
-import 'codemirror/addon/fold/foldgutter.css';
-import 'codemirror/lib/codemirror.css';
-import 'codemirror/theme/ayu-mirage.css';
 
 export const CssEditor: React.FC<{
   defaultCode: string;

--- a/packages/editor/src/components/CodeEditor/SchemaEditor.tsx
+++ b/packages/editor/src/components/CodeEditor/SchemaEditor.tsx
@@ -5,9 +5,6 @@ import { css } from '@emotion/css';
 import 'codemirror/mode/javascript/javascript';
 import 'codemirror/addon/fold/brace-fold';
 import 'codemirror/addon/fold/foldgutter';
-import 'codemirror/addon/fold/foldgutter.css';
-import 'codemirror/lib/codemirror.css';
-import 'codemirror/theme/ayu-mirage.css';
 
 export const SchemaEditor: React.FC<{
   defaultCode: string;

--- a/packages/editor/src/components/CodeEditor/StateEditor.tsx
+++ b/packages/editor/src/components/CodeEditor/StateEditor.tsx
@@ -5,8 +5,6 @@ import { css } from '@emotion/css';
 import 'codemirror/mode/javascript/javascript';
 import 'codemirror/addon/fold/brace-fold';
 import 'codemirror/addon/fold/foldgutter';
-import 'codemirror/addon/fold/foldgutter.css';
-import 'codemirror/lib/codemirror.css';
 import ErrorBoundary from '../ErrorBoundary';
 
 export const StateEditor: React.FC<{ code: string }> = ({ code }) => {

--- a/packages/editor/src/main.tsx
+++ b/packages/editor/src/main.tsx
@@ -7,8 +7,7 @@ import {
 import { Registry } from '@sunmao-ui/runtime/lib/services/registry';
 import { StrictMode } from 'react';
 import ReactDOM from 'react-dom';
-import 'react-grid-layout/css/styles.css';
-import 'react-resizable/css/styles.css';
+import './styles.css';
 
 import { Editor } from './components/Editor';
 import { App as _App, registry, stateManager, ui } from './setup';

--- a/packages/editor/src/playground.tsx
+++ b/packages/editor/src/playground.tsx
@@ -4,8 +4,7 @@ import { initSunmaoUI } from '@sunmao-ui/runtime';
 import { Registry } from '@sunmao-ui/runtime/lib/services/registry';
 import { StrictMode, useMemo, useState } from 'react';
 import ReactDOM from 'react-dom';
-import 'react-grid-layout/css/styles.css';
-import 'react-resizable/css/styles.css';
+import './styles.css';
 
 import { Editor } from './components/Editor';
 

--- a/packages/editor/src/styles.css
+++ b/packages/editor/src/styles.css
@@ -1,0 +1,6 @@
+@import 'react-grid-layout/css/styles.css';
+@import 'react-resizable/css/styles.css';
+
+@import 'codemirror/addon/fold/foldgutter.css';
+@import 'codemirror/lib/codemirror.css';
+@import 'codemirror/theme/ayu-mirage.css';

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -67,6 +67,8 @@
     "babel-jest": "^27.1.0",
     "eslint-plugin-react-hooks": "^4.3.0",
     "jest": "^27.1.0",
+    "postcss": "^8.4.5",
+    "postcss-import": "^14.0.2",
     "tsup": "^5.11.0",
     "typescript": "^4.5.0",
     "vite": "^2.6.13"

--- a/packages/runtime/postcss.config.js
+++ b/packages/runtime/postcss.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: [require('postcss-import')()],
+};

--- a/packages/runtime/src/components/_internal/GridLayout.tsx
+++ b/packages/runtime/src/components/_internal/GridLayout.tsx
@@ -2,8 +2,6 @@ import RGL from 'react-grid-layout';
 import React from 'react';
 import { css } from '@emotion/css';
 import { useResizeDetector } from 'react-resize-detector';
-import 'react-grid-layout/css/styles.css';
-import 'react-resizable/css/styles.css';
 import { DROP_EXAMPLE_SIZE_PREFIX, GRID_HEIGHT } from '../../constants';
 import { decodeDragDataTransfer } from '../../utils/encodeDragDataTransfer';
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -4,6 +4,7 @@ import { initRegistry } from './services/registry';
 import { initApiService } from './services/apiService';
 import { mountUtilMethods } from './services/util-methods';
 import { initGlobalHandlerMap } from './services/handler';
+import './style.css';
 
 export function initSunmaoUI(dependencies = {}) {
   const registry = initRegistry();

--- a/packages/runtime/src/style.css
+++ b/packages/runtime/src/style.css
@@ -1,0 +1,2 @@
+@import 'react-grid-layout/css/styles.css';
+@import 'react-resizable/css/styles.css';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5951,7 +5951,7 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
-is-core-module@^2.2.0, is-core-module@^2.5.0:
+is-core-module@^2.2.0, is-core-module@^2.5.0, is-core-module@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.0.tgz#0321336c3d0925e497fd97f5d95cb114a5ccd548"
   integrity sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==
@@ -8149,7 +8149,7 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.6:
+path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
@@ -8237,6 +8237,15 @@ popmotion@9.3.6:
     style-value-types "4.1.4"
     tslib "^2.1.0"
 
+postcss-import@^14.0.2:
+  version "14.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-import/-/postcss-import-14.0.2.tgz#60eff77e6be92e7b67fe469ec797d9424cae1aa1"
+  integrity sha512-BJ2pVK4KhUyMcqjuKs9RijV5tatNzNa73e/32aBVE/ejYPe37iH+6vAu9WvqUkB5OAYgLHzbSvzHnorybJCm9g==
+  dependencies:
+    postcss-value-parser "^4.0.0"
+    read-cache "^1.0.0"
+    resolve "^1.1.7"
+
 postcss-load-config@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-3.1.0.tgz#d39c47091c4aec37f50272373a6a648ef5e97829"
@@ -8246,6 +8255,11 @@ postcss-load-config@^3.0.1:
     lilconfig "^2.0.3"
     yaml "^1.10.2"
 
+postcss-value-parser@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
+  integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
+
 postcss@^8.3.8:
   version "8.3.11"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.11.tgz#c3beca7ea811cd5e1c4a3ec6d2e7599ef1f8f858"
@@ -8254,6 +8268,15 @@ postcss@^8.3.8:
     nanoid "^3.1.30"
     picocolors "^1.0.0"
     source-map-js "^0.6.2"
+
+postcss@^8.4.5:
+  version "8.4.5"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.5.tgz#bae665764dfd4c6fcc24dc0fdf7e7aa00cc77f95"
+  integrity sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==
+  dependencies:
+    nanoid "^3.1.30"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.1"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -8580,6 +8603,13 @@ react@^17.0.0, react@^17.0.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
+read-cache@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
+  integrity sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=
+  dependencies:
+    pify "^2.3.0"
+
 read-cmd-shim@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-2.0.0.tgz#4a50a71d6f0965364938e9038476f7eede3928d9"
@@ -8865,6 +8895,15 @@ resolve.exports@^1.1.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.0.tgz#5ce842b94b05146c0e03076985d1d0e7e48c90c9"
   integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
 
+resolve@^1.1.7:
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.21.0.tgz#b51adc97f3472e6a5cf4444d34bc9d6b9037591f"
+  integrity sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==
+  dependencies:
+    is-core-module "^2.8.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
@@ -9130,6 +9169,11 @@ source-map-js@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
   integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
+
+source-map-js@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.1.tgz#a1741c131e3c77d048252adfa24e23b908670caf"
+  integrity sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==
 
 source-map-support@^0.5.6:
   version "0.5.20"
@@ -9442,6 +9486,11 @@ supports-hyperlinks@^2.0.0:
   dependencies:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
+
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 symbol-tree@^3.2.4:
   version "3.2.4"


### PR DESCRIPTION
Some frameworks like Next.js does not like global CSS from node
modules, so we are going to bundle CSS into a single file with
postcss.

ref: https://github.com/vercel/next.js/discussions/27953