### PR TITLE
revert build to es5

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
     "lib"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm,iife --legacy-output --target es5",
+    "build": "tsup src/index.ts --format cjs,esm,iife --legacy-output",
     "dev": "npm run build -- --watch",
     "typings": "tsc --emitDeclarationOnly",
     "test": "jest",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -15,7 +15,7 @@
   ],
   "scripts": {
     "dev": "vite",
-    "build": "tsup src/main.tsx --format cjs,esm,iife --legacy-output --inject ../runtime/react-import.js --clean --no-splitting --sourcemap --target es5",
+    "build": "tsup src/main.tsx --format cjs,esm,iife --legacy-output --inject ../runtime/react-import.js --clean --no-splitting --sourcemap",
     "typings": "tsc --emitDeclarationOnly",
     "test": "jest",
     "prepublish": "npm run build && npm run typings"

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "dev": "vite",
     "test": "jest",
-    "build": "tsup src/index.ts --format cjs,esm,iife --legacy-output --inject ./react-import.js --clean --no-splitting --sourcemap --target es5",
+    "build": "tsup src/index.ts --format cjs,esm,iife --legacy-output --inject ./react-import.js --clean --no-splitting --sourcemap",
     "typings": "tsc --emitDeclarationOnly",
     "lint": "eslint src --ext .ts",
     "prepublish": "npm run build && npm run typings"


### PR DESCRIPTION
Building to es5 causes sourcemap broke and currently no solution. It may be a bug of tsup.