### PR TITLE
fix: set slot to different types depend on slot children's num

### DIFF
--- a/packages/chakra-ui-lib/src/components/Tabs.tsx
+++ b/packages/chakra-ui-lib/src/components/Tabs.tsx
@@ -74,7 +74,7 @@ export default implementRuntimeComponent({
       </TabList>
       <TabPanels>
         {tabNames.map((_, idx) => {
-          const ele = slotsElements.content ? slotsElements.content[idx] : placeholder;
+          const ele = slotsElements.content ? ([] as React.ReactElement[]).concat(slotsElements.content)[idx] : placeholder;
           return (
             <TabPanel
               key={idx}

--- a/packages/runtime/src/components/_internal/ImplWrapper.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper.tsx
@@ -150,15 +150,17 @@ const _ImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperProps>((props, 
     if (!childrenMap[c.id]) {
       return {};
     }
-    const res: Record<string, React.ReactElement[]> = {};
+    const res: Record<string, React.ReactElement[] | React.ReactElement> = {};
     for (const slot in childrenMap[c.id]) {
-      res[slot] = childrenMap[c.id][slot].map(child => {
+      const slotChildren = childrenMap[c.id][slot].map(child => {
         if (!childrenCache.get(child)) {
           const ele = <ImplWrapper key={child.id} {...props} component={child} />;
           childrenCache.set(child, ele);
         }
         return childrenCache.get(child)!;
       });
+
+      res[slot] = slotChildren.length === 1 ? slotChildren[0] : slotChildren;
     }
     return res;
   }

--- a/packages/runtime/src/types/Component.ts
+++ b/packages/runtime/src/types/Component.ts
@@ -24,7 +24,7 @@ export type ComponentImplProps<
 > = ImplWrapperProps<KSlot> &
   TraitResult<KStyleSlot, KEvent>['props'] &
   RuntimeFunctions<TState, TMethods> & {
-    slotsElements: Record<KSlot, React.ReactElement[]>;
+    slotsElements: Record<KSlot, React.ReactElement[] | React.ReactElement>;
   };
 
 export type ComponentImpl<


### PR DESCRIPTION
when only one child in slot, set slot to ReactElement instead of array