### PR TITLE
put prettier eslint config to the last

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,8 +8,8 @@
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:@typescript-eslint/recommended",
-    "prettier",
-    "standard"
+    "standard",
+    "prettier"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
@@ -48,5 +48,13 @@
     "react/jsx-wrap-multilines": ["error"],
     "react/jsx-tag-spacing": ["error"]
   },
-  "ignorePatterns": ["node_modules", "*.d.ts", "*.js", "package.json", "*.html", "*.spec.ts", "*.spec.tsx"]
+  "ignorePatterns": [
+    "node_modules",
+    "*.d.ts",
+    "*.js",
+    "package.json",
+    "*.html",
+    "*.spec.ts",
+    "*.spec.tsx"
+  ]
 }


### PR DESCRIPTION
Fix #253 

The only thing we need to do is to put the prettier eslint config to the last of the extensions, then it will override other rules to avoid conflict.

Quote from its documentation

> Make sure to put it last, so it gets the chance to override other configs.