### PR TITLE
fix: mask position calculation is wrong after scrolling

### DIFF
--- a/packages/editor/src/components/Editor.tsx
+++ b/packages/editor/src/components/Editor.tsx
@@ -145,24 +145,22 @@ export const Editor: React.FC<Props> = observer(
 
     const renderMain = () => {
       const appBox = (
-        <Box flex="1" background="gray.50" p={1} overflow="hidden">
-          <Box
-            width="full"
-            height="full"
-            background="white"
-            overflow="auto"
-            transform={`scale(${scale / 100})`}
-            position="relative"
-          >
-            <Box
-              id={DIALOG_CONTAINER_ID}
-              width="full"
-              height="full"
-              position="absolute"
-            />
-            <Box width="full" overflow="auto" position="relative">
-              <EditorMaskWrapper services={services}>{appComponent}</EditorMaskWrapper>
-            </Box>
+        <Box
+          id="editor-main"
+          display="flex"
+          flexDirection="column"
+          width="full"
+          height="full"
+          overflow="auto"
+          p={1}
+          transform={`scale(${scale / 100})`}
+          position="relative"
+        >
+          <EditorMaskWrapper services={services}>
+            {appComponent}
+            <Box id={DIALOG_CONTAINER_ID} />
+          </EditorMaskWrapper>
+          <Box id="warning-area" height="48px" position="relative" flex="0 0 auto">
             <WarningArea services={services} />
           </Box>
         </Box>

--- a/packages/editor/src/components/EditorMaskWrapper/EditorMask.tsx
+++ b/packages/editor/src/components/EditorMaskWrapper/EditorMask.tsx
@@ -34,45 +34,51 @@ type Props = {
   mousePosition: [number, number];
   dragOverSlotRef: React.MutableRefObject<string>;
   hoverComponentIdRef: React.MutableRefObject<string>;
+  wrapperRef: React.MutableRefObject<HTMLDivElement | null>;
 };
 
+
+// Read this pr to understand the coordinates system before you modify this component.
+// https://github.com/webzard-io/sunmao-ui/pull/286
 export const EditorMask: React.FC<Props> = observer((props: Props) => {
-  const { services, mousePosition, hoverComponentIdRef, dragOverSlotRef } = props;
+  const { services, mousePosition, wrapperRef, hoverComponentIdRef, dragOverSlotRef } =
+    props;
   const { eventBus, editorStore } = services;
   const { selectedComponentId, eleMap, isDraggingNewComponent } = editorStore;
-  const wrapperRef = useRef<HTMLDivElement>(null);
-  const wrapperRect = useRef<DOMRect>();
-  const [rects, setRects] = useState<Record<string, DOMRect>>({});
+  const maskContainerRef = useRef<HTMLDivElement>(null);
+  const maskContainerRect = useRef<DOMRect>();
+  const [coordinates, setCoordinates] = useState<Record<string, DOMRect>>({});
+  const [coordinatesOffset, setCoordinatedOffset] = useState<[number, number]>([0, 0]);
 
-  useEffect(() => {
-    wrapperRect.current = wrapperRef.current?.getBoundingClientRect();
-  }, []);
-
-  // get rects of all elements
-  const updateRects = useCallback(
+  // establish the coordinateSystem by getting all the rect of elements,
+  // and recording the current scroll Offset
+  // and the updating maskContainerRect, because maskContainer shares the same coordinates with app
+  const updateCoordinateSystem = useCallback(
     (eleMap: Map<string, HTMLElement>) => {
+      if (!wrapperRef.current) return;
       const _rects: Record<string, DOMRect> = {};
       for (const id of eleMap.keys()) {
         const ele = eleMap.get(id);
         const rect = ele?.getBoundingClientRect();
-        if (rect) {
-          _rects[id] = rect;
-        }
+        if (!rect) continue;
+        _rects[id] = rect;
       }
-      setRects(_rects);
+      maskContainerRect.current = maskContainerRef.current?.getBoundingClientRect();
+      setCoordinates(_rects);
+      setCoordinatedOffset([wrapperRef.current.scrollLeft, wrapperRef.current.scrollTop]);
     },
-    [setRects]
+    [wrapperRef]
   );
 
   useEffect(() => {
     eventBus.on('HTMLElementsUpdated', () => {
-      updateRects(eleMap);
+      updateCoordinateSystem(eleMap);
     });
-  }, [eleMap, eventBus, updateRects]);
+  }, [eleMap, eventBus, updateCoordinateSystem]);
 
-  // listen elements resize and update rects
+  // listen elements resize and update coordinates
   useEffect(() => {
-    const debouncedUpdateRects = debounce(updateRects, 50);
+    const debouncedUpdateRects = debounce(updateCoordinateSystem, 50);
     const resizeObserver = new ResizeObserver(() => {
       debouncedUpdateRects(eleMap);
     });
@@ -86,11 +92,16 @@ export const EditorMask: React.FC<Props> = observer((props: Props) => {
     return () => {
       resizeObserver.disconnect();
     };
-  }, [eleMap, setRects, updateRects]);
+  }, [eleMap, setCoordinates, updateCoordinateSystem]);
 
   const hoverComponentId = useMemo(() => {
-    return whereIsMouse(...mousePosition, rects);
-  }, [mousePosition, rects]);
+    const where = whereIsMouse(
+      mousePosition[0] - coordinatesOffset[0],
+      mousePosition[1] - coordinatesOffset[1],
+      coordinates
+    );
+    return where;
+  }, [coordinatesOffset, mousePosition, coordinates]);
 
   useEffect(() => {
     hoverComponentIdRef.current = hoverComponentId;
@@ -98,24 +109,24 @@ export const EditorMask: React.FC<Props> = observer((props: Props) => {
 
   const getMaskPosition = useCallback(
     (componentId: string) => {
-      const rect = rects[componentId];
+      const rect = coordinates[componentId];
       const padding = 4;
-      if (!wrapperRect.current || !rect) return;
+      if (!maskContainerRect.current || !wrapperRef.current || !rect) return;
       return {
         id: componentId,
         style: {
-          top: rect.top - wrapperRect.current.top - padding,
-          left: rect.left - wrapperRect.current.left - padding,
+          top: rect.top - maskContainerRect.current.top - padding,
+          left: rect.left - maskContainerRect.current.left - padding,
           height: rect.height + padding * 2,
           width: rect.width + padding * 2,
         },
       };
     },
-    [rects]
+    [coordinates, wrapperRef]
   );
 
   const hoverMaskPosition = useMemo(() => {
-    if (!wrapperRect.current || !hoverComponentId) {
+    if (!maskContainerRect.current || !hoverComponentId) {
       return undefined;
     }
 
@@ -123,7 +134,7 @@ export const EditorMask: React.FC<Props> = observer((props: Props) => {
   }, [hoverComponentId, getMaskPosition]);
 
   const selectedMaskPosition = useMemo(() => {
-    if (!wrapperRect.current || !selectedComponentId) return undefined;
+    if (!maskContainerRect.current || !selectedComponentId) return undefined;
 
     return getMaskPosition(selectedComponentId);
   }, [selectedComponentId, getMaskPosition]);
@@ -161,13 +172,14 @@ export const EditorMask: React.FC<Props> = observer((props: Props) => {
 
   return (
     <Box
+      id="editor-mask-container"
       position="absolute"
       top="0"
       left="0"
       right="0"
       bottom="0"
       pointerEvents="none"
-      ref={wrapperRef}
+      ref={maskContainerRef}
     >
       {isDraggingNewComponent ? dragMask : hoverMask}
       {selectMask}

--- a/packages/editor/src/components/EditorMaskWrapper/EditorMaskWrapper.tsx
+++ b/packages/editor/src/components/EditorMaskWrapper/EditorMaskWrapper.tsx
@@ -16,6 +16,8 @@ export const EditorMaskWrapper: React.FC<Props> = observer(props => {
   const { editorStore, eventBus, registry } = services;
   const { setSelectedComponentId, setExplorerMenuTab } = editorStore;
   const [mousePosition, setMousePosition] = useState<[number, number]>([0, 0]);
+  const [scrollOffset, setScrollOffset] = useState<[number, number]>([0, 0]);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
   const dragOverSlotRef = useRef<string>('');
   const hoverComponentIdRef = useRef<string>('');
 
@@ -23,8 +25,14 @@ export const EditorMaskWrapper: React.FC<Props> = observer(props => {
     setMousePosition([e.clientX, e.clientY]);
   };
   const onMouseLeave = () => {
-    setMousePosition([-1, -1]);
+    setMousePosition([-Infinity, -Infinity]);
   };
+  const onScroll = () => {
+    if (wrapperRef.current) {
+      setScrollOffset([wrapperRef.current.scrollLeft, wrapperRef.current.scrollTop]);
+    }
+  };
+
   const onClick = () => {
     setSelectedComponentId(hoverComponentIdRef.current);
   };
@@ -55,9 +63,17 @@ export const EditorMaskWrapper: React.FC<Props> = observer(props => {
     );
   };
 
+  const mousePositionWithOffset: [number, number] = [
+    mousePosition[0] + scrollOffset[0],
+    mousePosition[1] + scrollOffset[1],
+  ];
+
   return (
     <Box
+      id="editor-mask-wrapper"
       width="full"
+      height="0"
+      flex="1"
       overflow="auto"
       position="relative"
       onMouseMove={onMouseMove}
@@ -65,13 +81,16 @@ export const EditorMaskWrapper: React.FC<Props> = observer(props => {
       onClick={onClick}
       onDragOver={onDragOver}
       onDrop={onDrop}
+      onScroll={onScroll}
+      ref={wrapperRef}
     >
       {children}
       <EditorMask
         services={services}
-        mousePosition={mousePosition}
+        mousePosition={mousePositionWithOffset}
         hoverComponentIdRef={hoverComponentIdRef}
         dragOverSlotRef={dragOverSlotRef}
+        wrapperRef={wrapperRef}
       />
     </Box>
   );

--- a/packages/editor/src/components/WarningArea.tsx
+++ b/packages/editor/src/components/WarningArea.tsx
@@ -75,7 +75,8 @@ export const WarningArea: React.FC<Props> = observer(({ services }) => {
       paddingY="2"
       paddingX="4"
       boxShadow="0 0 4px rgba(0, 0, 0, 0.1)"
-      background='white'
+      background="white"
+      zIndex="1"
     >
       <HStack width="full" justifyContent="space-between">
         <Text fontSize="md" fontWeight="bold">

--- a/packages/runtime/src/App.tsx
+++ b/packages/runtime/src/App.tsx
@@ -40,7 +40,7 @@ export const App: React.FC<AppProps> = props => {
   }, [hooks, options]);
 
   return (
-    <div className="App" style={{ height: '100%', overflow: 'auto' }}>
+    <div className="App">
       {topLevelComponents.map(c => {
         return (
           <ImplWrapper


### PR DESCRIPTION
The coordiantes system of mask looks like this. It is established by get all the rect of elements and **will not change** until any component updates or resizes.

There is one thing that have to be taken in to consider, which is the **scroll offset**. If the app has been scrolled when we get the rect of elements, the rects value will include scroll offset, therefore the whole coordinates system will have offset. So we must record this offset at the moment we establish the system, and correct the offset in the later calculation.

One more thing to mention, the app could be scrolled even after the system is established. So there are 2 kinds of scroll offset: the current offset and the offset snapshot when we establish the system. They are different.

![截屏2022-02-17 上午11 34 28](https://user-images.githubusercontent.com/12260952/154401672-fdf5b85b-4af2-46aa-8d42-689ce007e1f5.png)

