### PR TITLE
improve the expression parser

### DIFF
--- a/packages/runtime/__tests__/expression.spec.ts
+++ b/packages/runtime/__tests__/expression.spec.ts
@@ -3,7 +3,7 @@ import { StateManager, parseExpression } from '../src/services/StateManager';
 describe('parseExpression function', () => {
   it('can parse {{}} expression', () => {
     expect(parseExpression('value')).toMatchObject(['value']);
-    // wrong: {{{id: 123}}}. Must have space between {{ and {
+    expect(parseExpression('{{{id: 123}}}')).toMatchObject([['{id: 123}']]);
     expect(parseExpression('{{ {id: 123} }}')).toMatchObject([[' {id: 123} ']]);
     expect(parseExpression('Hello, {{ value }}!')).toMatchObject([
       'Hello, ',


### PR DESCRIPTION
By introducing a looking ahead algorithm, now we can correctly parse expressions like `{{{a: 1}}}`.