### PR TITLE
fix component tree bug and improve interaction

### DIFF
--- a/packages/editor/src/components/StructureTree/ComponentItemView.tsx
+++ b/packages/editor/src/components/StructureTree/ComponentItemView.tsx
@@ -11,6 +11,8 @@ type Props = {
   noChevron: boolean;
   isExpanded?: boolean;
   onToggleExpanded?: () => void;
+  onDragStart?: () => void;
+  onDragEnd?: () => void;
 };
 
 export const ComponentItemView: React.FC<Props> = props => {
@@ -23,6 +25,8 @@ export const ComponentItemView: React.FC<Props> = props => {
     onClick,
     onToggleExpanded,
     onClickRemove,
+    onDragStart,
+    onDragEnd,
   } = props;
 
   const expandIcon = (
@@ -40,12 +44,17 @@ export const ComponentItemView: React.FC<Props> = props => {
     />
   );
 
-  const onDragStart = (e: React.DragEvent) => {
+  const _onDragStart = (e: React.DragEvent) => {
     e.dataTransfer.setData('moveComponent', id);
+    onDragStart && onDragStart();
+  };
+
+  const _onDragEnd = () => {
+    onDragEnd && onDragEnd();
   };
 
   return (
-    <Box width="full" padding="1" onDragStart={onDragStart} draggable>
+    <Box width="full" padding="1" onDragStart={_onDragStart} onDragEnd={_onDragEnd} draggable>
       {noChevron ? null : expandIcon}
       <HStack width="full" justify="space-between">
         <Text

--- a/packages/editor/src/components/StructureTree/ComponentTree.tsx
+++ b/packages/editor/src/components/StructureTree/ComponentTree.tsx
@@ -61,6 +61,7 @@ export const ComponentTree: React.FC<Props> = props => {
             parentId={component.id}
             parentSlot={_slot}
             services={services}
+            isExpanded={isExpanded}
             isDropInOnly
           >
             <Text fontSize="sm" color="gray.500">
@@ -87,7 +88,15 @@ export const ComponentTree: React.FC<Props> = props => {
         </Box>
       );
     });
-  }, [slots, childrenMap, component.id, selectedComponentId, onSelectComponent, services]);
+  }, [
+    slots,
+    childrenMap,
+    component.id,
+    selectedComponentId,
+    onSelectComponent,
+    services,
+    isExpanded,
+  ]);
 
   const onClickRemove = () => {
     eventBus.send(
@@ -105,13 +114,14 @@ export const ComponentTree: React.FC<Props> = props => {
       spacing="0"
       width="full"
       alignItems="start"
-      marginTop='0 !important'
+      marginTop="0 !important"
     >
       <DropComponentWrapper
         componentId={component.id}
         parentSlot={slot}
         parentId={parentId}
         services={props.services}
+        isExpanded={isExpanded}
       >
         <ComponentItemView
           id={component.id}

--- a/packages/editor/src/components/StructureTree/ComponentTree.tsx
+++ b/packages/editor/src/components/StructureTree/ComponentTree.tsx
@@ -15,6 +15,7 @@ type Props = {
   selectedComponentId: string;
   onSelectComponent: (id: string) => void;
   services: EditorServices;
+  isAncestorDragging: boolean
 };
 
 export const ComponentTree: React.FC<Props> = props => {
@@ -26,10 +27,12 @@ export const ComponentTree: React.FC<Props> = props => {
     selectedComponentId,
     onSelectComponent,
     services,
+    isAncestorDragging,
   } = props;
   const { registry, eventBus } = services;
   const slots = registry.getComponentByType(component.type).spec.slots;
   const [isExpanded, setIsExpanded] = useState(true);
+  const [isDragging, setIsDragging] = useState(false);
 
   const slotsEle = useMemo(() => {
     if (slots.length === 0) {
@@ -51,6 +54,7 @@ export const ComponentTree: React.FC<Props> = props => {
               selectedComponentId={selectedComponentId}
               onSelectComponent={onSelectComponent}
               services={services}
+              isAncestorDragging={isAncestorDragging || isDragging}
             />
           );
         });
@@ -63,6 +67,7 @@ export const ComponentTree: React.FC<Props> = props => {
             services={services}
             isExpanded={isExpanded}
             isDropInOnly
+            droppable={!isAncestorDragging && !isDragging}
           >
             <Text fontSize="sm" color="gray.500">
               Empty
@@ -88,15 +93,7 @@ export const ComponentTree: React.FC<Props> = props => {
         </Box>
       );
     });
-  }, [
-    slots,
-    childrenMap,
-    component.id,
-    selectedComponentId,
-    onSelectComponent,
-    services,
-    isExpanded,
-  ]);
+  }, [slots, childrenMap, component.id, selectedComponentId, onSelectComponent, services, isAncestorDragging, isDragging, isExpanded]);
 
   const onClickRemove = () => {
     eventBus.send(
@@ -122,6 +119,7 @@ export const ComponentTree: React.FC<Props> = props => {
         parentId={parentId}
         services={props.services}
         isExpanded={isExpanded}
+        droppable={!isAncestorDragging && !isDragging}
       >
         <ComponentItemView
           id={component.id}
@@ -134,6 +132,8 @@ export const ComponentTree: React.FC<Props> = props => {
           noChevron={slots.length === 0}
           isExpanded={isExpanded}
           onToggleExpanded={() => setIsExpanded(prev => !prev)}
+          onDragStart={() => setIsDragging(true)}
+          onDragEnd={() => setIsDragging(false)}
         />
       </DropComponentWrapper>
       {isExpanded ? slotsEle : undefined}

--- a/packages/editor/src/components/StructureTree/DropComponentWrapper.tsx
+++ b/packages/editor/src/components/StructureTree/DropComponentWrapper.tsx
@@ -10,17 +10,29 @@ type Props = {
   isExpanded: boolean;
   // only can be drop in and cannot drop before or after
   isDropInOnly?: boolean;
+  droppable: boolean;
   services: EditorServices;
 };
 
 export const DropComponentWrapper: React.FC<Props> = props => {
-  const { componentId, parentId, parentSlot, services, isDropInOnly, isExpanded } = props;
+  const {
+    componentId,
+    parentId,
+    parentSlot,
+    services,
+    isDropInOnly,
+    isExpanded,
+    droppable,
+  } = props;
   const { registry, eventBus } = services;
   const ref = useRef<HTMLDivElement>(null);
   const [dragDirection, setDragDirection] = useState<'prev' | 'next' | undefined>();
   const [isDragOver, setIsDragOver] = useState<boolean>(false);
 
   const onDragOver = (e: React.DragEvent) => {
+    if (!droppable) {
+      return;
+    }
     setIsDragOver(true);
     e.preventDefault();
     e.stopPropagation();
@@ -39,11 +51,17 @@ export const DropComponentWrapper: React.FC<Props> = props => {
   };
 
   const onDragLeave = () => {
+    if (!droppable) {
+      return;
+    }
     setDragDirection(undefined);
     setIsDragOver(false);
   };
 
   const onDrop = (e: React.DragEvent) => {
+    if (!droppable) {
+      return;
+    }
     e.stopPropagation();
     e.preventDefault();
     const creatingComponent = e.dataTransfer?.getData('component') || '';
@@ -55,7 +73,6 @@ export const DropComponentWrapper: React.FC<Props> = props => {
     if (dragDirection === 'next' && isExpanded) {
       targetParentId = componentId;
       targetParentSlot = 'content';
-      // should be the first of children
       targetId = undefined;
     }
 
@@ -94,9 +111,9 @@ export const DropComponentWrapper: React.FC<Props> = props => {
     if (isDropInOnly) return '';
     switch (dragDirection) {
       case 'prev':
-        return '0 -1px 0 0 red';
+        return '0 -2px 0 0 #ff8080';
       case 'next':
-        return '0 1px 0 0 red';
+        return '0 2px 0 0 #ff8080';
     }
   }, [dragDirection, isDropInOnly]);
 
@@ -105,7 +122,7 @@ export const DropComponentWrapper: React.FC<Props> = props => {
       ref={ref}
       width="full"
       boxShadow={boxShadow}
-      background={isDropInOnly && isDragOver ? 'pink' : undefined}
+      background={ isDragOver ? '#ffc6c6' : undefined}
       onDrop={onDrop}
       onDragOver={onDragOver}
       onDragLeave={onDragLeave}

--- a/packages/editor/src/components/StructureTree/StructureTree.tsx
+++ b/packages/editor/src/components/StructureTree/StructureTree.tsx
@@ -62,6 +62,7 @@ function Placeholder(props: { services: EditorServices }) {
           parentSlot={undefined}
           services={props.services}
           isDropInOnly
+          isExpanded={false}
         >
           <Text padding="2" border="2px dashed" color="gray.400" borderColor="gray.400">
             There is no components now. You can drag component into here to create it.

--- a/packages/editor/src/components/StructureTree/StructureTree.tsx
+++ b/packages/editor/src/components/StructureTree/StructureTree.tsx
@@ -38,6 +38,7 @@ export const StructureTree: React.FC<Props> = props => {
         selectedComponentId={selectedComponentId}
         onSelectComponent={onSelectComponent}
         services={services}
+        isAncestorDragging={false}
       />
     ));
   }, [realComponents, selectedComponentId, onSelectComponent, services]);
@@ -63,6 +64,7 @@ function Placeholder(props: { services: EditorServices }) {
           services={props.services}
           isDropInOnly
           isExpanded={false}
+          droppable
         >
           <Text padding="2" border="2px dashed" color="gray.400" borderColor="gray.400">
             There is no components now. You can drag component into here to create it.

--- a/packages/editor/src/operations/branch/component/createComponentBranchOperation.ts
+++ b/packages/editor/src/operations/branch/component/createComponentBranchOperation.ts
@@ -87,7 +87,7 @@ export class CreateComponentBranchOperation extends BaseBranchOperation<CreateCo
       }
     }
 
-    if (this.context.targetId && this.context.direction) {
+    if (this.context.direction) {
       this.operationStack.insert(
         new AdjustComponentOrderLeafOperation(this.registry, {
           componentId: this.context.componentId as ComponentId,

--- a/packages/editor/src/operations/branch/component/moveComponentBranchOperation.ts
+++ b/packages/editor/src/operations/branch/component/moveComponentBranchOperation.ts
@@ -29,7 +29,7 @@ export class MoveComponentBranchOperation extends BaseBranchOperation<MoveCompon
       );
     }
 
-    if (this.context.targetId && this.context.direction) {
+    if (this.context.direction) {
       this.operationStack.insert(
         new AdjustComponentOrderLeafOperation(this.registry, {
           componentId: this.context.fromId as ComponentId,

--- a/packages/editor/src/operations/leaf/component/adjustComponentOrderLeafOperation.ts
+++ b/packages/editor/src/operations/leaf/component/adjustComponentOrderLeafOperation.ts
@@ -3,7 +3,7 @@ import { ComponentId } from '../../../AppModel/IAppModel';
 import { BaseLeafOperation } from '../../type';
 export type AdjustComponentOrderLeafOperationContext = {
   componentId: ComponentId;
-  targetId: ComponentId;
+  targetId?: ComponentId;
   direction: 'prev' | 'next';
 };
 


### PR DESCRIPTION
#292 
1. Improve dragging interaction
2. Prevent component from being dragged to its self or children.

Now the component tree drag interaction is like notion.

https://user-images.githubusercontent.com/12260952/155073622-9613e6eb-28ce-44c2-b521-0e824716f3eb.mov

 