### PR TITLE
Make sure event handler is called in sync order and with the lateset state.

### DIFF
--- a/examples/box/index.json
+++ b/examples/box/index.json
@@ -6,7 +6,7 @@
       "components": [
         {
           "id": "test_btn",
-          "type": "plain/v1/button",
+          "type": "chakra_ui/v1/button",
           "properties": { "text": { "raw": "Click", "format": "plain" } },
           "traits": [
             {

--- a/examples/conditional-render/hidden.json
+++ b/examples/conditional-render/hidden.json
@@ -9,7 +9,7 @@
       "components": [
         {
           "id": "btn",
-          "type": "plain/v1/button",
+          "type": "chakra_ui/v1/button",
           "properties": {
             "text": {
               "raw": "toggle text",

--- a/examples/dialog/index.json
+++ b/examples/dialog/index.json
@@ -15,7 +15,7 @@
         },
         {
           "id": "btn",
-          "type": "plain/v1/button",
+          "type": "chakra_ui/v1/button",
           "properties": {
             "text": {
               "raw": "**Open Dialog**",

--- a/examples/fetch-list/lazy.json
+++ b/examples/fetch-list/lazy.json
@@ -9,7 +9,7 @@
       "components": [
         {
           "id": "fetch_btn",
-          "type": "plain/v1/button",
+          "type": "chakra_ui/v1/button",
           "properties": {
             "text": {
               "raw": "Click to Fetch!",

--- a/examples/form/formInDialog.json
+++ b/examples/form/formInDialog.json
@@ -342,7 +342,7 @@
         },
         {
           "id": "typeRadioGroup",
-          "type": "chakra_ui/v1/radio_group",
+          "type": "chakra_ui/v1/radioGroup",
           "properties": {
             "defaultValue": "{{ table.selectedItem ? table.selectedItem.type : \"notSharing\" }}"
           },
@@ -425,7 +425,7 @@
         },
         {
           "id": "sizeInput",
-          "type": "chakra_ui/v1/number_input",
+          "type": "chakra_ui/v1/numberInput",
           "properties": {
             "defaultValue": "{{ table.selectedItem ? table.selectedItem.size : 0 }}",
             "min": 0,

--- a/examples/input-components/inputValidation.json
+++ b/examples/input-components/inputValidation.json
@@ -75,7 +75,7 @@
         },
         {
           "id": "submitButton",
-          "type": "plain/v1/button",
+          "type": "chakra_ui/v1/button",
           "properties": {
             "text": {
               "raw": "提交",

--- a/examples/input-components/numberInput.json
+++ b/examples/input-components/numberInput.json
@@ -15,7 +15,7 @@
         },
         {
           "id": "number_input",
-          "type": "chakra_ui/v1/number_input",
+          "type": "chakra_ui/v1/numberInput",
           "properties": {
             "min": 10,
             "max": 100,

--- a/examples/radio/index.json
+++ b/examples/radio/index.json
@@ -15,7 +15,7 @@
         },
         {
           "id": "radio_group",
-          "type": "chakra_ui/v1/radio_group",
+          "type": "chakra_ui/v1/radioGroup",
           "properties": {
             "defaultValue": 1,
             "isNumerical": true

--- a/examples/router/hash.json
+++ b/examples/router/hash.json
@@ -112,7 +112,7 @@
         },
         {
           "id": "switch_button",
-          "type": "plain/v1/button",
+          "type": "chakra_ui/v1/button",
           "properties": {
             "text": {
               "raw": "switch",
@@ -154,7 +154,7 @@
         },
         {
           "id": "redirect_button",
-          "type": "plain/v1/button",
+          "type": "chakra_ui/v1/button",
           "properties": {
             "text": {
               "raw": "redirect",

--- a/examples/router/index.json
+++ b/examples/router/index.json
@@ -112,7 +112,7 @@
         },
         {
           "id": "switch_button",
-          "type": "plain/v1/button",
+          "type": "chakra_ui/v1/button",
           "properties": {
             "text": {
               "raw": "switch",
@@ -154,7 +154,7 @@
         },
         {
           "id": "redirect_button",
-          "type": "plain/v1/button",
+          "type": "chakra_ui/v1/button",
           "properties": {
             "text": {
               "raw": "redirect",

--- a/examples/router/params.json
+++ b/examples/router/params.json
@@ -56,7 +56,7 @@
         },
         {
           "id": "nav_btn",
-          "type": "plain/v1/button",
+          "type": "chakra_ui/v1/button",
           "properties": {
             "text": {
               "raw": "navigate",

--- a/examples/table/staticData.json
+++ b/examples/table/staticData.json
@@ -19,6 +19,7 @@
           "properties": {
             "size": "lg",
             "rowsPerPage": 5,
+            "majorKey": "id",
             "data": [
               {
                 "id": 1,

--- a/examples/table/tableWithForm.json
+++ b/examples/table/tableWithForm.json
@@ -292,7 +292,7 @@
         },
         {
           "id": "typeRadioGroup",
-          "type": "chakra_ui/v1/radio_group",
+          "type": "chakra_ui/v1/radioGroup",
           "properties": {
             "defaultValue": "{{ table.selectedItem ? table.selectedItem.type : \"notSharing\" }}"
           },
@@ -375,7 +375,7 @@
         },
         {
           "id": "sizeInput",
-          "type": "chakra_ui/v1/number_input",
+          "type": "chakra_ui/v1/numberInput",
           "properties": {
             "defaultValue": "{{ table.selectedItem ? table.selectedItem.size : 0 }}",
             "min": 0,

--- a/packages/chakra-ui-lib/src/components/Table/Table.tsx
+++ b/packages/chakra-ui-lib/src/components/Table/Table.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { isArray, sortBy } from 'lodash-es';
 import {
   Table as BaseTable,
@@ -23,6 +23,7 @@ type SortRule = {
 
 export const TableImpl = implementTable(
   ({
+    component,
     data,
     majorKey,
     rowsPerPage,
@@ -184,13 +185,14 @@ export const TableImpl = implementTable(
                   }}
                 >
                   {isMultiSelect ? checkbox : undefined}
-                  {columns.map(column => (
+                  {columns.map((column, j) => (
                     <TableTd
                       index={i}
                       key={column.key}
                       item={item}
-                      column={column}
                       onClickItem={() => selectItem(item)}
+                      rawColumn={(component.properties.columns as any)[j]}
+                      column={column}
                       services={services}
                       app={app}
                     />

--- a/packages/chakra-ui-lib/src/components/Table/Table.tsx
+++ b/packages/chakra-ui-lib/src/components/Table/Table.tsx
@@ -15,6 +15,8 @@ import { TablePagination } from './Pagination';
 
 import { TableTd } from './TableTd';
 import { implementTable } from './spec';
+import { ColumnsPropertySchema } from './TableTypes';
+import { Static } from '@sinclair/typebox';
 
 type SortRule = {
   key: string;
@@ -191,7 +193,7 @@ export const TableImpl = implementTable(
                       key={column.key}
                       item={item}
                       onClickItem={() => selectItem(item)}
-                      rawColumn={(component.properties.columns as any)[j]}
+                      rawColumn={(component.properties.columns as Static<typeof ColumnsPropertySchema>)[j]}
                       column={column}
                       services={services}
                       app={app}

--- a/packages/editor/src/components/DataSource/ApiForm/ApiForm.tsx
+++ b/packages/editor/src/components/DataSource/ApiForm/ApiForm.tsx
@@ -54,7 +54,7 @@ export const ApiForm: React.FC<Props> = props => {
   const { registry, eventBus } = services;
   const result = useMemo(() => {
     return store[api.id]?.fetch ?? {};
-  }, [store[api.id], api.id]);
+  }, [api.id, store]);
   const traitIndex = useMemo(
     () => api.traits.findIndex(({ type }) => type === 'core/v1/fetch'),
     [api.traits]

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -36,6 +36,7 @@
     "@vue/shared": "^3.2.20",
     "copy-to-clipboard": "^3.3.1",
     "dayjs": "^1.10.6",
+    "immer": "^9.0.12",
     "lodash-es": "^4.17.21",
     "mitt": "^3.0.0",
     "nanoid": "^3.1.23",

--- a/packages/runtime/src/services/apiService.ts
+++ b/packages/runtime/src/services/apiService.ts
@@ -35,7 +35,7 @@ export function initApiService() {
 function mountSystemMethods(apiService: ApiService) {
   apiService.on('uiMethod', ({ componentId, name, parameters }) => {
     switch (componentId) {
-      // hanlder as module event
+      // handler as module event
       case GLOBAL_MODULE_ID:
         apiService.send('moduleEvent', {
           fromId: parameters.moduleId,

--- a/packages/runtime/src/traits/core/Event.tsx
+++ b/packages/runtime/src/traits/core/Event.tsx
@@ -30,7 +30,7 @@ const useEventTrait: TraitImpl<Static<typeof PropsSchema>> = ({
     if (!callbackQueueMap[handler.type]) {
       callbackQueueMap[handler.type] = [];
     }
-    if (!handler.wait) {
+    if (!handler.wait || !handler.wait.time) {
       callbackQueueMap[handler.type].push(cb);
     } else {
       callbackQueueMap[handler.type].push(

--- a/packages/runtime/src/traits/core/Fetch.tsx
+++ b/packages/runtime/src/traits/core/Fetch.tsx
@@ -6,6 +6,7 @@ import { FetchTraitPropertiesSchema } from '../../types/traitPropertiesSchema';
 const hasFetchedMap = new Map<string, boolean>();
 
 const useFetchTrait: TraitImpl<Static<typeof FetchTraitPropertiesSchema>> = ({
+  trait,
   url,
   method,
   lazy: _lazy,
@@ -15,8 +16,6 @@ const useFetchTrait: TraitImpl<Static<typeof FetchTraitPropertiesSchema>> = ({
   services,
   subscribeMethods,
   componentId,
-  onComplete,
-  onError,
 }) => {
   const hashId = `#${componentId}@${'fetch'}`;
   const hasFetched = hasFetchedMap.get(hashId);
@@ -58,11 +57,15 @@ const useFetchTrait: TraitImpl<Static<typeof FetchTraitPropertiesSchema>> = ({
               error: undefined,
             },
           });
-          onComplete?.forEach(event => {
+          const rawOnComplete = trait.properties.onComplete as Static<
+            typeof FetchTraitPropertiesSchema
+          >['onComplete'];
+          rawOnComplete?.forEach(handler => {
+            const evaledHandler = services.stateManager.deepEval(handler, false);
             services.apiService.send('uiMethod', {
-              componentId: event.componentId,
-              name: event.method.name,
-              parameters: event.method.parameters,
+              componentId: evaledHandler.componentId,
+              name: evaledHandler.method.name,
+              parameters: evaledHandler.method.parameters,
             });
           });
         } else {
@@ -76,11 +79,15 @@ const useFetchTrait: TraitImpl<Static<typeof FetchTraitPropertiesSchema>> = ({
               error,
             },
           });
-          onError?.forEach(event => {
+          const rawOnError = trait.properties.onError as Static<
+            typeof FetchTraitPropertiesSchema
+          >['onError'];
+          rawOnError?.forEach(handler => {
+            const evaledHandler = services.stateManager.deepEval(handler, false);
             services.apiService.send('uiMethod', {
-              componentId: event.componentId,
-              name: event.method.name,
-              parameters: event.method.parameters,
+              componentId: evaledHandler.componentId,
+              name: evaledHandler.method.name,
+              parameters: evaledHandler.method.parameters,
             });
           });
         }
@@ -94,11 +101,15 @@ const useFetchTrait: TraitImpl<Static<typeof FetchTraitPropertiesSchema>> = ({
             error: error instanceof Error ? error : new Error(error),
           },
         });
-        onError?.forEach(event => {
+        const rawOnError = trait.properties.onError as Static<
+          typeof FetchTraitPropertiesSchema
+        >['onError'];
+        rawOnError?.forEach(handler => {
+          const evaledHandler = services.stateManager.deepEval(handler, false);
           services.apiService.send('uiMethod', {
-            componentId: event.componentId,
-            name: event.method.name,
-            parameters: event.method.parameters,
+            componentId: evaledHandler.componentId,
+            name: evaledHandler.method.name,
+            parameters: evaledHandler.method.parameters,
           });
         });
       }

--- a/packages/runtime/src/types/trait.ts
+++ b/packages/runtime/src/types/trait.ts
@@ -1,4 +1,4 @@
-import { RuntimeTrait } from '@sunmao-ui/core';
+import { RuntimeTrait, RuntimeTraitSchema } from '@sunmao-ui/core';
 import { UIServices } from './application';
 import { RuntimeFunctions } from './component';
 
@@ -15,6 +15,7 @@ export type TraitResult<KStyleSlot extends string, KEvent extends string> = {
 export type TraitImpl<T = any> = (
   props: T &
     RuntimeFunctions<unknown, unknown> & {
+      trait: RuntimeTraitSchema;
       componentId: string;
       services: UIServices;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5972,6 +5972,11 @@ ignore@^5.1.4, ignore@^5.1.8:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
+immer@^9.0.12:
+  version "9.0.12"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.12.tgz#2d33ddf3ee1d247deab9d707ca472c8c942a0f20"
+  integrity sha512-lk7UNmSbAukB5B6dh9fnh5D0bJTOFKxVg2cyJWTYrWRfhLrLMBquONcUs3aFq507hNoIZEDDh8lb8UtOizSMhA==
+
 immer@^9.0.6:
   version "9.0.6"
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.6.tgz#7a96bf2674d06c8143e327cbf73539388ddf1a73"


### PR DESCRIPTION
# Fixed Bugs
1. Fix: event handler is called async when `wait.time` is `0`.
2. Fix: `deepEvalAndWatch` method generates mutable object.

# Changes
In order to get the latest state, every time before an event handler is going to be called, **the handler schema need to be evaled again**. Otherwise, the event handler will be called with state of last frame.

This logic needs to be added to component **manually**. But only few components need to add it because these components need to trigger events by itself, like button in `table` or `onComplete` in `fetch`. Most components' events are handled by event trait.