### PR TITLE
EditorMask support components in dialog

### DIFF
--- a/packages/chakra-ui-lib/src/components/Dialog.tsx
+++ b/packages/chakra-ui-lib/src/components/Dialog.tsx
@@ -96,16 +96,21 @@ export default implementRuntimeComponent({
       colorScheme: 'blue',
     },
     customStyle,
-    elementRef,
+    getElement,
   }) => {
     const [isOpen, setIsOpen] = useState(false);
     const [title, setTitle] = useState(customerTitle || '');
     const cancelRef = useRef(null);
+    const contentRef = useRef<HTMLDivElement | null>(null);
     const containerRef = useRef<HTMLElement | null>(null);
 
     useEffect(() => {
       containerRef.current = document.getElementById(DIALOG_CONTAINER_ID);
     }, [containerRef]);
+
+    useEffect(() => {
+      getElement && contentRef.current && getElement(contentRef.current);
+    }, [getElement, isOpen]);
 
     useEffect(() => {
       subscribeMethods({
@@ -152,7 +157,7 @@ export default implementRuntimeComponent({
           <AlertDialogContent
             className={`${customStyle?.content}`}
             {...(containerRef.current ? dialogContentProps : {})}
-            ref={elementRef}
+            ref={contentRef}
           >
             <AlertDialogHeader>{title}</AlertDialogHeader>
             <AlertDialogBody>{slotsElements.content}</AlertDialogBody>

--- a/packages/editor/src/components/EditorMaskWrapper/EditorMaskWrapper.tsx
+++ b/packages/editor/src/components/EditorMaskWrapper/EditorMaskWrapper.tsx
@@ -76,9 +76,10 @@ export const EditorMaskWrapper: React.FC<Props> = observer(props => {
       flex="1"
       overflow="auto"
       position="relative"
+      // some components stop click event propagation, so here we should capture onClick
+      onClickCapture={onClick}
       onMouseMove={onMouseMove}
       onMouseLeave={onMouseLeave}
-      onClick={onClick}
       onDragOver={onDragOver}
       onDrop={onDrop}
       onScroll={onScroll}

--- a/packages/editor/src/components/StructureTree/ComponentTree.tsx
+++ b/packages/editor/src/components/StructureTree/ComponentTree.tsx
@@ -68,6 +68,7 @@ export const ComponentTree: React.FC<Props> = props => {
             isExpanded={isExpanded}
             isDropInOnly
             droppable={!isAncestorDragging && !isDragging}
+            hasSlot={true}
           >
             <Text fontSize="sm" color="gray.500">
               Empty
@@ -120,6 +121,7 @@ export const ComponentTree: React.FC<Props> = props => {
         services={props.services}
         isExpanded={isExpanded}
         droppable={!isAncestorDragging && !isDragging}
+        hasSlot={slots.length > 0}
       >
         <ComponentItemView
           id={component.id}

--- a/packages/editor/src/components/StructureTree/DropComponentWrapper.tsx
+++ b/packages/editor/src/components/StructureTree/DropComponentWrapper.tsx
@@ -94,7 +94,6 @@ export const DropComponentWrapper: React.FC<Props> = props => {
 
     // create component as children
     if (creatingComponent) {
-      console.log('dragDirection', dragDirection)
       eventBus.send(
         'operation',
         genOperation(registry, 'createComponent', {

--- a/packages/editor/src/components/StructureTree/DropComponentWrapper.tsx
+++ b/packages/editor/src/components/StructureTree/DropComponentWrapper.tsx
@@ -12,6 +12,7 @@ type Props = {
   isDropInOnly?: boolean;
   droppable: boolean;
   services: EditorServices;
+  hasSlot: boolean;
 };
 
 export const DropComponentWrapper: React.FC<Props> = props => {
@@ -23,6 +24,7 @@ export const DropComponentWrapper: React.FC<Props> = props => {
     isDropInOnly,
     isExpanded,
     droppable,
+    hasSlot,
   } = props;
   const { registry, eventBus } = services;
   const ref = useRef<HTMLDivElement>(null);
@@ -70,7 +72,7 @@ export const DropComponentWrapper: React.FC<Props> = props => {
     let targetParentId = parentId;
     let targetParentSlot = parentSlot;
     let targetId = componentId;
-    if (dragDirection === 'next' && isExpanded) {
+    if (dragDirection === 'next' && isExpanded && hasSlot) {
       targetParentId = componentId;
       targetParentSlot = 'content';
       targetId = undefined;
@@ -92,6 +94,7 @@ export const DropComponentWrapper: React.FC<Props> = props => {
 
     // create component as children
     if (creatingComponent) {
+      console.log('dragDirection', dragDirection)
       eventBus.send(
         'operation',
         genOperation(registry, 'createComponent', {

--- a/packages/editor/src/components/StructureTree/StructureTree.tsx
+++ b/packages/editor/src/components/StructureTree/StructureTree.tsx
@@ -65,6 +65,7 @@ function Placeholder(props: { services: EditorServices }) {
           isDropInOnly
           isExpanded={false}
           droppable
+          hasSlot={true}
         >
           <Text padding="2" border="2px dashed" color="gray.400" borderColor="gray.400">
             There is no components now. You can drag component into here to create it.

--- a/packages/editor/src/init.tsx
+++ b/packages/editor/src/init.tsx
@@ -50,11 +50,11 @@ export function initSunmaoUIEditor(props: SunmaoUIEditorProps = {}) {
   const didUpdate = () => {
     eventBus.send('HTMLElementsUpdated');
   };
-  const didHtmlUpdate = () => {
+  const didDomUpdate = () => {
     eventBus.send('HTMLElementsUpdated');
   };
 
-  const ui = initSunmaoUI({ ...props.runtimeProps, hooks: { didMount, didUpdate, didHtmlUpdate } });
+  const ui = initSunmaoUI({ ...props.runtimeProps, hooks: { didMount, didUpdate, didDomUpdate } });
 
   const App = ui.App;
   const registry = ui.registry;

--- a/packages/editor/src/init.tsx
+++ b/packages/editor/src/init.tsx
@@ -50,8 +50,11 @@ export function initSunmaoUIEditor(props: SunmaoUIEditorProps = {}) {
   const didUpdate = () => {
     eventBus.send('HTMLElementsUpdated');
   };
+  const didHtmlUpdate = () => {
+    eventBus.send('HTMLElementsUpdated');
+  };
 
-  const ui = initSunmaoUI({ ...props.runtimeProps, hooks: { didMount, didUpdate } });
+  const ui = initSunmaoUI({ ...props.runtimeProps, hooks: { didMount, didUpdate, didHtmlUpdate } });
 
   const App = ui.App;
   const registry = ui.registry;

--- a/packages/runtime/src/App.tsx
+++ b/packages/runtime/src/App.tsx
@@ -50,6 +50,7 @@ export const App: React.FC<AppProps> = props => {
             childrenMap={childrenMap}
             app={app}
             gridCallbacks={gridCallbacks}
+            hooks={hooks}
           />
         );
       })}

--- a/packages/runtime/src/components/_internal/ImplWrapper.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper.tsx
@@ -6,7 +6,7 @@ import { ImplWrapperProps, TraitResult } from '../../types';
 import { shallowCompareArray } from '../../utils/shallowCompareArray';
 
 const _ImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperProps>((props, ref) => {
-  const { component: c, app, children, services, childrenMap } = props;
+  const { component: c, app, children, services, childrenMap, hooks } = props;
   const { registry, stateManager, globalHandlerMap, apiService, eleMap } = props.services;
   const childrenCache = new Map<RuntimeComponentSchema, React.ReactElement>();
 
@@ -20,6 +20,7 @@ const _ImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperProps>((props, 
   const eleRef = useRef<HTMLElement>();
   const onRef = (ele: HTMLElement) => {
     eleMap.set(c.id, ele);
+    hooks?.didHtmlUpdate && hooks?.didHtmlUpdate();
   };
 
   useEffect(() => {

--- a/packages/runtime/src/components/_internal/ImplWrapper.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper.tsx
@@ -20,7 +20,7 @@ const _ImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperProps>((props, 
   const eleRef = useRef<HTMLElement>();
   const onRef = (ele: HTMLElement) => {
     eleMap.set(c.id, ele);
-    hooks?.didHtmlUpdate && hooks?.didHtmlUpdate();
+    hooks?.didDomUpdate && hooks?.didDomUpdate();
   };
 
   useEffect(() => {

--- a/packages/runtime/src/types/application.ts
+++ b/packages/runtime/src/types/application.ts
@@ -20,6 +20,7 @@ export type GridCallbacks = {
 
 export type ComponentParamsFromApp = {
   gridCallbacks?: GridCallbacks;
+  hooks?: AppHooks;
 };
 
 export type AppProps = {
@@ -27,10 +28,13 @@ export type AppProps = {
   services: UIServices;
   debugStore?: boolean;
   debugEvent?: boolean;
-  hooks?: AppHooks;
 } & ComponentParamsFromApp;
 
 export type AppHooks = {
+  // after app first render
   didMount?: () => void;
+  // app updates after schema changes
   didUpdate?: () => void;
+  // app updates after html elements change
+  didHtmlUpdate?: () => void;
 };

--- a/packages/runtime/src/types/application.ts
+++ b/packages/runtime/src/types/application.ts
@@ -35,6 +35,6 @@ export type AppHooks = {
   didMount?: () => void;
   // app updates after schema changes
   didUpdate?: () => void;
-  // app updates after html elements change
-  didHtmlUpdate?: () => void;
+  // app updates after dom change(dose not include updates from schema change)
+  didDomUpdate?: () => void;
 };


### PR DESCRIPTION
1. EditorMask support components in dialog #291 
2. fix: cannot drop component after components which have no slots

This implementation is kind of workaround for now. The key point is to filter the elements in dialog by detecting whether an element is child of `dialogContainerElement`.
The limitation of this way is that it cannot detect modals which append to body or multiple modals situation.
The ultimate solution maybe adding a z-axis in `rectMap`. But since we don't have multiple dialogs or popover for now, so we can implement it in the future.