### PR TITLE
improve editor mask label

### DIFF
--- a/packages/arco-lib/src/generated/types/Table.ts
+++ b/packages/arco-lib/src/generated/types/Table.ts
@@ -51,7 +51,6 @@ export const ColumnSchema = Type.Object({
 export const TablePropsSchema = Type.Object({
   data: Type.Array(Type.Any(), {
     title: 'Data',
-    widget: 'expression',
     category: Category.Data,
     weight: 0,
   }),

--- a/packages/editor/src/components/Editor.tsx
+++ b/packages/editor/src/components/Editor.tsx
@@ -139,25 +139,27 @@ export const Editor: React.FC<Props> = observer(
 
     const renderMain = () => {
       const appBox = (
-        <Box
-          id="editor-main"
-          display="flex"
-          flexDirection="column"
-          width="full"
-          height="full"
-          overflow="auto"
-          p={1}
-          transform={`scale(${scale / 100})`}
-          position="relative"
-        >
-          <EditorMaskWrapper services={services}>
-            {appComponent}
-            <Box id={DIALOG_CONTAINER_ID} />
-          </EditorMaskWrapper>
+        <Flex flexDirection="column" width="full" height="full">
+          <Box
+            id="editor-main"
+            display="flex"
+            flexDirection="column"
+            width="full"
+            height="full"
+            overflow="auto"
+            padding="20px"
+            transform={`scale(${scale / 100})`}
+            position="relative"
+          >
+            <EditorMaskWrapper services={services}>
+              {appComponent}
+              <Box id={DIALOG_CONTAINER_ID} />
+            </EditorMaskWrapper>
+          </Box>
           <Box id="warning-area" height="48px" position="relative" flex="0 0 auto">
             <WarningArea services={services} />
           </Box>
-        </Box>
+        </Flex>
       );
 
       if (codeMode) {

--- a/packages/editor/src/components/EditorMaskWrapper/EditorMask.tsx
+++ b/packages/editor/src/components/EditorMaskWrapper/EditorMask.tsx
@@ -12,9 +12,15 @@ const outlineMaskTextStyle = css`
   z-index: 1;
   right: 0px;
   padding: 0 4px;
-  font-size: 14px;
-  font-weight: black;
+  height: 20px;
+  right: 0;
+  max-width: 100%;
   color: white;
+  font-size: 14px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  transform: translateY(-100%);
 `;
 
 const outlineMaskStyle = css`

--- a/packages/editor/src/components/EditorMaskWrapper/EditorMaskWrapper.tsx
+++ b/packages/editor/src/components/EditorMaskWrapper/EditorMaskWrapper.tsx
@@ -74,7 +74,7 @@ export const EditorMaskWrapper: React.FC<Props> = observer(props => {
       width="full"
       height="0"
       flex="1"
-      overflow="auto"
+      overflow="visible"
       position="relative"
       // some components stop click event propagation, so here we should capture onClick
       onClickCapture={onClick}


### PR DESCRIPTION
1. Increase to canvas padding to avoid the top component's label hiding.
2. Move label to the top of component to avoid label covering the component.

<img width="802" alt="截屏2022-03-07 下午4 08 15" src="https://user-images.githubusercontent.com/12260952/156992803-2596c763-14c2-4378-9c5b-40118df0d0dd.png">
<img width="129" alt="截屏2022-03-07 下午4 08 31" src="https://user-images.githubusercontent.com/12260952/156992815-b0259dce-b9af-469d-9187-4a33903e36a6.png">
