### PR TITLE
Add FileInput Component

### DIFF
--- a/packages/editor/src/components/DataSource/ApiForm/ApiForm.tsx
+++ b/packages/editor/src/components/DataSource/ApiForm/ApiForm.tsx
@@ -132,7 +132,9 @@ export const ApiForm: React.FC<Props> = props => {
       ...(trait?.properties as Static<typeof FetchTraitPropertiesSchema>),
     });
     setTabIndex(0);
-  }, [trait.properties]);
+  // do not add formik into dependencies, otherwise it will cause infinite loop
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [trait?.properties]);
   useEffect(() => {
     if (api.id) {
       setName(api.id);

--- a/packages/editor/src/components/DataSource/ApiForm/Body.tsx
+++ b/packages/editor/src/components/DataSource/ApiForm/Body.tsx
@@ -41,12 +41,11 @@ export const Body: React.FC<Props> = props => {
       <Select value={values.bodyType} onChange={onBodyTypeChange}>
         <option value="json">JSON</option>
         <option value="formData">Form Data</option>
-        <option value="raw">raw</option>
       </Select>
       <Text fontSize="lg" fontWeight="bold">
         Body
       </Text>
-      <Box width='full'>
+      <Box width="full">
         <KeyValueWidget
           component={api}
           schema={mergeWidgetOptionsIntoSchema(schema, {

--- a/packages/editor/src/components/DataSource/ApiForm/Body.tsx
+++ b/packages/editor/src/components/DataSource/ApiForm/Body.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box } from '@chakra-ui/react';
+import { Box, Select, Text, VStack } from '@chakra-ui/react';
 import {
   KeyValueWidget,
   WidgetProps,
@@ -28,19 +28,37 @@ export const Body: React.FC<Props> = props => {
     formik.submitForm();
   };
 
+  const onBodyTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    formik.setFieldValue('bodyType', e.target.value);
+    formik.submitForm();
+  };
+
   return (
-    <Box>
-      <KeyValueWidget
-        component={api}
-        schema={mergeWidgetOptionsIntoSchema(schema, {
-          minNum: 1,
-          isShowHeader: true,
-        })}
-        level={1}
-        value={values.body}
-        services={services}
-        onChange={onChange}
-      />
-    </Box>
+    <VStack alignItems="start">
+      <Text fontSize="lg" fontWeight="bold">
+        BodyType
+      </Text>
+      <Select value={values.bodyType} onChange={onBodyTypeChange}>
+        <option value="json">JSON</option>
+        <option value="formData">Form Data</option>
+        <option value="raw">raw</option>
+      </Select>
+      <Text fontSize="lg" fontWeight="bold">
+        Body
+      </Text>
+      <Box width='full'>
+        <KeyValueWidget
+          component={api}
+          schema={mergeWidgetOptionsIntoSchema(schema, {
+            minNum: 1,
+            isShowHeader: true,
+          })}
+          level={1}
+          value={values.body}
+          services={services}
+          onChange={onChange}
+        />
+      </Box>
+    </VStack>
   );
 };

--- a/packages/editor/src/components/DataSource/DataSource.tsx
+++ b/packages/editor/src/components/DataSource/DataSource.tsx
@@ -69,7 +69,7 @@ export const DataSource: React.FC<Props> = props => {
     <VStack spacing="2" alignItems="stretch">
       <Flex padding="4" paddingBottom="0">
         <Text fontSize="lg" fontWeight="bold">
-          Datasource
+          DataSource
         </Text>
         <Spacer />
         <Menu>

--- a/packages/runtime/src/components/core/FileInput.tsx
+++ b/packages/runtime/src/components/core/FileInput.tsx
@@ -1,0 +1,67 @@
+import { Type } from '@sinclair/typebox';
+import { css } from '@emotion/css';
+import { implementRuntimeComponent } from '../../utils/buildKit';
+import React, { useRef } from 'react';
+
+const StateSchema = Type.Object({
+  files: Type.Any(),
+});
+
+const PropsSchema = Type.Object({});
+
+export default implementRuntimeComponent({
+  version: 'core/v1',
+  metadata: {
+    name: 'fileInput',
+    displayName: 'File Input',
+    description: 'Select file',
+    isDraggable: true,
+    isResizable: false,
+    exampleProperties: {},
+    exampleSize: [1, 1],
+    annotations: {
+      category: 'Input',
+    },
+  },
+  spec: {
+    properties: PropsSchema,
+    state: StateSchema,
+    methods: {},
+    slots: [],
+    styleSlots: ['content'],
+    events: [],
+  },
+})(({ mergeState, customStyle, elementRef }) => {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    mergeState({
+      files: e.target.files,
+    });
+    if (!e.target.files) return;
+    const formData = new FormData();
+    formData.append('myFile', e.target.files[0]);
+    console.log('formData', formData)
+    fetch('http://localhost:3000/', {
+      method: 'POST',
+      body: formData,
+    })
+      .then(data => {
+        console.log(data);
+      })
+      .catch(error => {
+        console.error(error);
+      });
+    console.log(e.target.files);
+  };
+
+  return (
+    <div
+      ref={elementRef}
+      className={css`
+        ${customStyle?.content}
+      `}
+    >
+      <input ref={inputRef} type="file" name="文件上传" onChange={onChange} />
+    </div>
+  );
+});

--- a/packages/runtime/src/services/Registry.tsx
+++ b/packages/runtime/src/services/Registry.tsx
@@ -7,6 +7,7 @@ import CoreRouter from '../components/core/Router';
 import CoreDummy from '../components/core/Dummy';
 import CoreModuleContainer from '../components/core/ModuleContainer';
 import CoreStack from '../components/core/Stack';
+import CoreFileInput from '../components/core/FileInput';
 
 // traits
 import CoreArrayState from '../traits/core/ArrayState';
@@ -201,6 +202,7 @@ export function initRegistry(
   registry.registerComponent(CoreDummy);
   registry.registerComponent(CoreModuleContainer);
   registry.registerComponent(CoreStack);
+  registry.registerComponent(CoreFileInput);
 
   registry.registerTrait(CoreState);
   registry.registerTrait(CoreArrayState);

--- a/packages/runtime/src/traits/core/Fetch.tsx
+++ b/packages/runtime/src/traits/core/Fetch.tsx
@@ -6,7 +6,6 @@ import { FetchTraitPropertiesSchema } from '../../types/traitPropertiesSchema';
 const FetchTraitFactory: TraitImplFactory<Static<typeof FetchTraitPropertiesSchema>> =
   () => {
     const hasFetchedMap = new Map<string, boolean>();
-
     return ({
       trait,
       url,
@@ -14,6 +13,7 @@ const FetchTraitFactory: TraitImplFactory<Static<typeof FetchTraitPropertiesSche
       lazy: _lazy,
       headers: _headers,
       body,
+      bodyType,
       mergeState,
       services,
       subscribeMethods,
@@ -24,7 +24,7 @@ const FetchTraitFactory: TraitImplFactory<Static<typeof FetchTraitPropertiesSche
       const lazy = _lazy === undefined ? true : _lazy;
 
       const fetchData = () => {
-        // TODO: clear when component destory
+        // TODO: clear when component destroy
         hasFetchedMap.set(hashId, true);
         // FIXME: listen to the header change
         const headers = new Headers();
@@ -42,16 +42,34 @@ const FetchTraitFactory: TraitImplFactory<Static<typeof FetchTraitPropertiesSche
           },
         });
 
+        let realBody: string | FormData = '';
+
+        switch (bodyType) {
+          case 'json':
+            realBody = JSON.stringify(body);
+            break;
+          case 'formData':
+            realBody = new FormData();
+            for (const key in body) {
+              realBody.append(key, body[key]);
+            }
+        }
+
         // fetch data
         fetch(url, {
           method,
           headers,
-          body: method === 'get' ? undefined : JSON.stringify(body),
+          body: realBody,
         }).then(
           async response => {
             if (response.ok) {
               // handle 20x/30x
-              const data = await response.json();
+              let data: any;
+              if (response.headers.get('Content-Type') === 'application/json') {
+                data = await response.json();
+              } else {
+                data = await response.text();
+              }
               mergeState({
                 fetch: {
                   loading: false,
@@ -94,6 +112,7 @@ const FetchTraitFactory: TraitImplFactory<Static<typeof FetchTraitPropertiesSche
               });
             }
           },
+
           async error => {
             console.warn(error);
             mergeState({

--- a/packages/runtime/src/traits/core/Fetch.tsx
+++ b/packages/runtime/src/traits/core/Fetch.tsx
@@ -42,24 +42,25 @@ const FetchTraitFactory: TraitImplFactory<Static<typeof FetchTraitPropertiesSche
           },
         });
 
-        let realBody: string | FormData = '';
+        let reqBody: string | FormData = '';
 
         switch (bodyType) {
           case 'json':
-            realBody = JSON.stringify(body);
+            reqBody = JSON.stringify(body);
             break;
           case 'formData':
-            realBody = new FormData();
+            reqBody = new FormData();
             for (const key in body) {
-              realBody.append(key, body[key]);
+              reqBody.append(key, body[key]);
             }
+            break;
         }
 
         // fetch data
         fetch(url, {
           method,
           headers,
-          body: realBody,
+          body: reqBody,
         }).then(
           async response => {
             if (response.ok) {

--- a/packages/runtime/src/types/traitPropertiesSchema.ts
+++ b/packages/runtime/src/types/traitPropertiesSchema.ts
@@ -56,6 +56,14 @@ export const FetchTraitPropertiesSchema = Type.Object({
   body: Type.Record(Type.String(), Type.String(), {
     title: 'Body',
   }),
+  bodyType: Type.KeyOf(
+    Type.Object({
+      json: Type.String(),
+      formData: Type.String(),
+      raw: Type.String(),
+    }),
+    { title: 'Body Type' },
+  ),
   onComplete: Type.Array(EventCallBackHandlerSchema),
   onError: Type.Array(EventCallBackHandlerSchema),
 });

--- a/packages/runtime/src/types/traitPropertiesSchema.ts
+++ b/packages/runtime/src/types/traitPropertiesSchema.ts
@@ -60,7 +60,6 @@ export const FetchTraitPropertiesSchema = Type.Object({
     Type.Object({
       json: Type.String(),
       formData: Type.String(),
-      raw: Type.String(),
     }),
     { title: 'Body Type' },
   ),


### PR DESCRIPTION
# Changes
1. add a core component: FileInput. FileInput can select files and store files in `stateStore`.
2. add a `bodyType` property for fetch trait. Because upload file need body to be `FormData` instead of JSON. Now support `formData` and `json`.

The settings of uploading file.
![截屏2022-03-08 下午2 21 26](https://user-images.githubusercontent.com/12260952/157178835-5ed2b936-5b00-4ffe-8416-4e70be6d7b06.png)
 