### PR TITLE
trim expression before eval

### DIFF
--- a/packages/runtime/src/services/StateManager.ts
+++ b/packages/runtime/src/services/StateManager.ts
@@ -169,7 +169,8 @@ const EXPRESSION = {
   START: '{{',
   END: '}}',
 };
-export const parseExpression = (exp: string, parseListItem = false): ExpChunk[] => {
+export const parseExpression = (rawExp: string, parseListItem = false): ExpChunk[] => {
+  const exp = rawExp.trim();
   // $listItem cannot be evaled in stateStore, so don't mark it as dynamic
   // unless explicitly pass parseListItem as true
   if (


### PR DESCRIPTION
To fix this bug. If there is an space at the end of expression accidentally, the expression will be evaled as string, instead of an object, which is not expected.

![截屏2022-03-23 下午4 46 24](https://user-images.githubusercontent.com/12260952/159660978-b46e5756-d188-4199-9ca9-8d2320856281.png)
![截屏2022-03-23 下午4 46 28](https://user-images.githubusercontent.com/12260952/159660984-f07b6c15-ceb0-4a95-b342-8abf3fe9cc21.png)
![截屏2022-03-23 下午4 46 42](https://user-images.githubusercontent.com/12260952/159660985-c93e76a4-c9fd-4205-9a21-77bdd84d37ab.png)
![截屏2022-03-23 下午4 46 48](https://user-images.githubusercontent.com/12260952/159660986-06e5e862-072c-4169-9c6b-d1eb69dfde28.png)
