### PR TITLE
Fix/windlike patch

### DIFF
--- a/packages/arco-lib/src/components/Table.tsx
+++ b/packages/arco-lib/src/components/Table.tsx
@@ -10,13 +10,7 @@ import { css } from '@emotion/css';
 import { Type, Static } from '@sinclair/typebox';
 import { FALLBACK_METADATA, getComponentProps } from '../sunmao-helper';
 import { TablePropsSpec, ColumnSpec } from '../generated/types/Table';
-import React, {
-  ReactNode,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { sortBy } from 'lodash-es';
 import {
   LIST_ITEM_EXP,
@@ -27,7 +21,7 @@ import {
 import { TableInstance } from '@arco-design/web-react/es/Table/table';
 
 const TableStateSpec = Type.Object({
-  clickedRow:Type.Optional(Type.Any()),
+  clickedRow: Type.Optional(Type.Any()),
   selectedRows: Type.Array(Type.Any()),
   selectedRow: Type.Optional(Type.Any()),
   selectedRowKeys: Type.Array(Type.String()),
@@ -133,7 +127,7 @@ export const exampleProperties: Static<typeof TablePropsSpec> = {
   pagination: {
     pageSize: 6,
   },
-  rowClick:false,
+  rowClick: false,
   tableLayoutFixed: false,
   borderCell: false,
   stripe: false,
@@ -243,9 +237,16 @@ export const Table = implementRuntimeComponent({
     }
 
     newColumn.render = (ceilValue: any, record: any, index: number) => {
-      const evaledColumn: ColumnProperty = services.stateManager.deepEval(column, true, {
-        [LIST_ITEM_EXP]: record,
-      });
+      const evalOptions = {
+        evalListItem: true,
+        scopeObject: {
+          [LIST_ITEM_EXP]: record,
+        },
+      };
+      const evaledColumn: ColumnProperty = services.stateManager.deepEval(
+        column,
+        evalOptions
+      );
       const value = record[evaledColumn.dataIndex];
 
       let colItem;
@@ -257,8 +258,7 @@ export const Table = implementRuntimeComponent({
             if (!rawColumn.btnCfg) return;
             const evaledButtonConfig = services.stateManager.deepEval(
               rawColumn.btnCfg,
-              true,
-              { [LIST_ITEM_EXP]: record }
+              evalOptions
             );
 
             evaledButtonConfig.handlers.forEach(handler => {

--- a/packages/chakra-ui-lib/src/components/Table/TableTd.tsx
+++ b/packages/chakra-ui-lib/src/components/Table/TableTd.tsx
@@ -7,34 +7,36 @@ import {
   LIST_ITEM_INDEX_EXP,
   ModuleRenderer,
   UIServices,
-  ExpressionError
+  ExpressionError,
 } from '@sunmao-ui/runtime';
 
 export const TableTd: React.FC<{
   index: number;
   item: any;
   column: Static<typeof ColumnSpec>;
-  rawColumn: Static<typeof ColumnsPropertySpec>[0]
+  rawColumn: Static<typeof ColumnsPropertySpec>[0];
   onClickItem: () => void;
   services: UIServices;
   app?: RuntimeApplication;
 }> = props => {
   const { item, index, column, rawColumn, onClickItem, services, app } = props;
+  const evalOptions = {
+    evalListItem: true,
+    scopeObject: {
+      [LIST_ITEM_EXP]: item,
+    },
+  };
   let value = item[column.key];
   let buttonConfig = column.buttonConfig;
 
   if (column.displayValue) {
-    const result = services.stateManager.maskedEval(column.displayValue, true, {
-      [LIST_ITEM_EXP]: item,
-    });
+    const result = services.stateManager.maskedEval(column.displayValue, evalOptions);
 
     value = result instanceof ExpressionError ? '' : result;
   }
 
   if (column.buttonConfig) {
-    buttonConfig = services.stateManager.deepEval(column.buttonConfig, true, {
-      [LIST_ITEM_EXP]: item,
-    });
+    buttonConfig = services.stateManager.deepEval(column.buttonConfig, evalOptions);
   }
 
   let content = value;
@@ -57,9 +59,7 @@ export const TableTd: React.FC<{
       const onClick = () => {
         onClickItem();
         rawColumn.buttonConfig.handlers.forEach(handler => {
-          const evaledHandler = services.stateManager.deepEval(handler, true, {
-            [LIST_ITEM_EXP]: item,
-          });
+          const evaledHandler = services.stateManager.deepEval(handler, evalOptions);
           services.apiService.send('uiMethod', {
             componentId: evaledHandler.componentId,
             name: evaledHandler.method.name,

--- a/packages/editor-sdk/src/components/Widgets/ExpressionWidget.tsx
+++ b/packages/editor-sdk/src/components/Widgets/ExpressionWidget.tsx
@@ -155,7 +155,8 @@ export const ExpressionWidget: React.FC<
   const evalCode = useCallback(
     (code: string) => {
       try {
-        const result = services.stateManager.maskedEval(getParsedValue(code, type));
+        const value = getParsedValue(code, type);
+        const result = isExpression(code) ? services.stateManager.maskedEval(value) : value;
 
         if (result instanceof ExpressionError) {
           throw result;

--- a/packages/runtime/__tests__/expression.spec.ts
+++ b/packages/runtime/__tests__/expression.spec.ts
@@ -1,4 +1,8 @@
-import { StateManager, parseExpression, ExpressionError } from '../src/services/StateManager';
+import {
+  StateManager,
+  parseExpression,
+  ExpressionError,
+} from '../src/services/StateManager';
 
 describe('parseExpression function', () => {
   it('can parse {{}} expression', () => {
@@ -81,41 +85,52 @@ describe('evalExpression function', () => {
   };
   const stateStore = new StateManager();
   it('can eval {{}} expression', () => {
-    expect(stateStore.maskedEval('value', false, scope)).toEqual('value');
-    expect(stateStore.maskedEval('{{true}}', false, scope)).toEqual(true);
-    expect(stateStore.maskedEval('{{ false }}', false, scope)).toEqual(false);
-    expect(stateStore.maskedEval('{{[]}}', false, scope)).toEqual([]);
-    expect(stateStore.maskedEval('{{ [] }}', false, scope)).toEqual([]);
-    expect(stateStore.maskedEval('{{ [1,2,3] }}', false, scope)).toEqual([1, 2, 3]);
+    const evalOptions = { evalListItem: false, scopeObject: scope };
 
-    expect(stateStore.maskedEval('{{ {} }}', false, scope)).toEqual({});
-    expect(stateStore.maskedEval('{{ {id: 123} }}', false, scope)).toEqual({ id: 123 });
-    expect(stateStore.maskedEval('{{nothing}}', false, scope) instanceof ExpressionError).toEqual(true);
+    expect(stateStore.maskedEval('value', evalOptions)).toEqual('value');
+    expect(stateStore.maskedEval('{{true}}', evalOptions)).toEqual(true);
+    expect(stateStore.maskedEval('{{ false }}', evalOptions)).toEqual(false);
+    expect(stateStore.maskedEval('{{[]}}', evalOptions)).toEqual([]);
+    expect(stateStore.maskedEval('{{ [] }}', evalOptions)).toEqual([]);
+    expect(stateStore.maskedEval('{{ [1,2,3] }}', evalOptions)).toEqual([1, 2, 3]);
 
-    expect(stateStore.maskedEval('{{input1.value}}', false, scope)).toEqual('world');
-    expect(stateStore.maskedEval('{{checkbox.value}}', false, scope)).toEqual(true);
-    expect(stateStore.maskedEval('{{fetch.data}}', false, scope)).toMatchObject([
+    expect(stateStore.maskedEval('{{ {} }}', evalOptions)).toEqual({});
+    expect(stateStore.maskedEval('{{ {id: 123} }}', evalOptions)).toEqual({ id: 123 });
+    expect(
+      stateStore.maskedEval('{{nothing}}', evalOptions) instanceof ExpressionError
+    ).toEqual(true);
+
+    expect(stateStore.maskedEval('{{input1.value}}', evalOptions)).toEqual('world');
+    expect(stateStore.maskedEval('{{checkbox.value}}', evalOptions)).toEqual(true);
+    expect(stateStore.maskedEval('{{fetch.data}}', evalOptions)).toMatchObject([
       { id: 1 },
       { id: 2 },
     ]);
 
-    expect(stateStore.maskedEval('{{{{}}}}', false, scope)).toEqual(undefined);
+    expect(stateStore.maskedEval('{{{{}}}}', evalOptions)).toEqual(undefined);
 
     expect(
-      stateStore.maskedEval('{{ value }}, {{ input1.value }}!', false, scope)
+      stateStore.maskedEval('{{ value }}, {{ input1.value }}!', evalOptions)
     ).toEqual('Hello, world!');
   });
 
   it('can eval $listItem expression', () => {
-    expect(stateStore.maskedEval('{{ $listItem.value }}', false, scope)).toEqual(
-      '{{ $listItem.value }}'
-    );
-    expect(stateStore.maskedEval('{{ $listItem.value }}', true, scope)).toEqual('foo');
+    expect(
+      stateStore.maskedEval('{{ $listItem.value }}', {
+        evalListItem: false,
+        scopeObject: scope,
+      })
+    ).toEqual('{{ $listItem.value }}');
+    expect(
+      stateStore.maskedEval('{{ $listItem.value }}', {
+        evalListItem: true,
+        scopeObject: scope,
+      })
+    ).toEqual('foo');
     expect(
       stateStore.maskedEval(
         '{{ {{$listItem.value}}Input.value + {{$moduleId}}Fetch.value }}!',
-        true,
-        scope
+        { evalListItem: true, scopeObject: scope }
       )
     ).toEqual('Yes, ok!');
   });

--- a/packages/runtime/src/components/_internal/ImplWrapper.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { merge } from 'lodash-es';
 import { RuntimeComponentSchema, RuntimeTraitSchema } from '@sunmao-ui/core';
-import { ExpressionError } from '../../services/StateManager';
 import { watch } from '../../utils/watchReactivity';
 import { ImplWrapperProps, TraitResult } from '../../types';
 import { shallowCompareArray } from '../../utils/shallowCompareArray';
@@ -102,7 +101,8 @@ const _ImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperProps>((props, 
             return newResults;
           });
           stops.push(stop);
-        }
+        },
+        { fallbackWhenError: () => undefined }
       );
       properties.push(result);
     });
@@ -134,7 +134,10 @@ const _ImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperProps>((props, 
 
   // component properties
   const [evaledComponentProperties, setEvaledComponentProperties] = useState(() => {
-    return merge(stateManager.deepEval(c.properties), propsFromTraits);
+    return merge(
+      stateManager.deepEval(c.properties, { fallbackWhenError: () => undefined }),
+      propsFromTraits
+    );
   });
   // eval component properties
   useEffect(() => {
@@ -142,7 +145,8 @@ const _ImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperProps>((props, 
       c.properties,
       ({ result: newResult }: any) => {
         setEvaledComponentProperties({ ...newResult });
-      }
+      },
+      { fallbackWhenError: () => undefined }
     );
     // must keep this line, reason is the same as above
     setEvaledComponentProperties({ ...result });
@@ -155,17 +159,10 @@ const _ImplWrapper = React.forwardRef<HTMLDivElement, ImplWrapperProps>((props, 
     };
   }, [c.id, stateManager.store]);
 
-  const mergedProps = useMemo(() => {
-    const allProps: Record<string, any> = { ...evaledComponentProperties, ...propsFromTraits };
-
-    for (const key in allProps) {
-      if (allProps[key] instanceof ExpressionError) {
-        allProps[key] = undefined;
-      }
-    }
-
-    return allProps;
-  }, [evaledComponentProperties, propsFromTraits]);
+  const mergedProps = useMemo(
+    () => ({ ...evaledComponentProperties, ...propsFromTraits }),
+    [evaledComponentProperties, propsFromTraits]
+  );
 
   function genSlotsElements() {
     if (!childrenMap[c.id]) {

--- a/packages/runtime/src/traits/core/Fetch.tsx
+++ b/packages/runtime/src/traits/core/Fetch.tsx
@@ -143,7 +143,7 @@ const FetchTraitFactory: TraitImplFactory<Static<typeof FetchTraitPropertiesSpec
               typeof FetchTraitPropertiesSpec
             >['onError'];
             rawOnError?.forEach(handler => {
-              const evaledHandler = services.stateManager.deepEval(handler, false);
+              const evaledHandler = services.stateManager.deepEval(handler, { evalListItem: false });
               services.apiService.send('uiMethod', {
                 componentId: evaledHandler.componentId,
                 name: evaledHandler.method.name,


### PR DESCRIPTION
Should traverse all the properties to fallback value to `undefined` when the expression parse error, so I change the `maskedEval`'s parameters and add the `fallbackWhenError` option to handle how to fallback the value.