### PR TITLE
Feat/arco

### DIFF
--- a/packages/arco-lib/src/components/Form/FormControl.tsx
+++ b/packages/arco-lib/src/components/Form/FormControl.tsx
@@ -35,6 +35,14 @@ const exampleProperties: Static<typeof FormControlPropsSpec> = {
   labelAlign: 'left',
   colon: false,
   help: '',
+  labelCol: {
+    span: 3,
+    offset: 0,
+  },
+  wrapperCol: {
+    span: 21,
+    offset: 0,
+  },
 };
 
 export const FormControl = implementRuntimeComponent({

--- a/packages/arco-lib/src/components/Input.tsx
+++ b/packages/arco-lib/src/components/Input.tsx
@@ -19,6 +19,7 @@ const exampleProperties: Static<typeof InputPropsSpec> = {
   disabled: false,
   readOnly: false,
   defaultValue: '',
+  updateWhenDefaultValueChanges: false,
   placeholder: 'please input',
   error: false,
   size: 'default',
@@ -46,7 +47,14 @@ const options = {
 };
 
 export const Input = implementRuntimeComponent(options)(props => {
-  const { getElement, slotsElements, customStyle, callbackMap, mergeState } = props;
+  const {
+    getElement,
+    updateWhenDefaultValueChanges,
+    slotsElements,
+    customStyle,
+    callbackMap,
+    mergeState,
+  } = props;
   const { defaultValue, ...cProps } = getComponentProps(props);
   const ref = useRef<RefInputType | null>(null);
   const [value, setValue] = useState(defaultValue);
@@ -57,6 +65,13 @@ export const Input = implementRuntimeComponent(options)(props => {
       getElement(ele);
     }
   }, [getElement, ref]);
+
+  useEffect(() => {
+    if (updateWhenDefaultValueChanges) {
+      setValue(defaultValue);
+      mergeState({ value: defaultValue });
+    }
+  }, [defaultValue, updateWhenDefaultValueChanges]);
 
   const onChange = useCallback(
     value => {

--- a/packages/arco-lib/src/components/Link.tsx
+++ b/packages/arco-lib/src/components/Link.tsx
@@ -11,12 +11,20 @@ const LinkStateSpec = Type.Object({});
 const exampleProperties: Static<typeof LinkPropsSpec> = {
   disabled: false,
   hoverable: true,
-  status: 'warning',
+  status: 'default',
   href: 'https://www.smartx.com/',
   content: 'Link',
 };
 
-const options = {
+
+const statusMap = {
+  default: undefined,
+  success: 'success',
+  error: 'error',
+  warning: 'warning',
+} as const;
+
+export const Link = implementRuntimeComponent({
   version: 'arco/v1',
   metadata: {
     ...FALLBACK_METADATA,
@@ -35,16 +43,14 @@ const options = {
     styleSlots: ['content'],
     events: [],
   },
-};
-
-export const Link = implementRuntimeComponent(options)(props => {
+})(props => {
   const { content, status, ...cProps } = getComponentProps(props);
   const { elementRef, customStyle } = props;
 
   return (
     <BaseLink
       ref={elementRef}
-      status={status}
+      status={statusMap[status]}
       className={css(customStyle?.content)}
       {...cProps}
     >

--- a/packages/arco-lib/src/components/Slider.tsx
+++ b/packages/arco-lib/src/components/Slider.tsx
@@ -1,0 +1,63 @@
+import { Slider as BaseSlider } from "@arco-design/web-react";
+import { implementRuntimeComponent } from "@sunmao-ui/runtime";
+import { css } from "@emotion/css";
+import { Type, Static } from "@sinclair/typebox";
+import { FALLBACK_METADATA, getComponentProps } from "../sunmao-helper";
+import { SliderPropsSpec as BaseSliderPropsSpec } from "../generated/types/Slider";
+
+const SliderPropsSpec = Type.Object(BaseSliderPropsSpec);
+const SliderStateSpec = Type.Object({});
+
+const exampleProperties: Static<typeof SliderPropsSpec> = {
+  min: 0,
+  max: 100,
+  disabled: false,
+  tooltipVisible: true,
+  range: false,
+  vertical: false,
+  marks: {},
+  onlyMarkValue: false,
+  reverse: false,
+  step:1,
+  showTicks:false
+};
+
+export const Slider = implementRuntimeComponent({
+  version: "arco/v1",
+  metadata: {
+    ...FALLBACK_METADATA,
+    name: "slider",
+    displayName: "Slider",
+    exampleProperties,
+    annotations: {
+      category: "Display",
+    },
+  },
+  spec: {
+    properties: SliderPropsSpec,
+    state: SliderStateSpec,
+    methods: {},
+    slots: [],
+    styleSlots: ["content"],
+    events: ["onChange", "onAfterChange"],
+  },
+})((props) => {
+  const { ...cProps } = getComponentProps(props);
+  const { customStyle, elementRef, callbackMap, mergeState } = props;
+
+  return (
+    <BaseSlider
+      ref={elementRef}
+      onChange={(val) => {
+        mergeState({ value: val });
+        callbackMap?.onChange?.();
+      }}
+      onAfterChange={(val) => {
+        mergeState({ value: val });
+        callbackMap?.onAfterChange?.();
+      }}
+      className={css(customStyle?.content)}
+      {...cProps}
+    />
+  );
+});

--- a/packages/arco-lib/src/components/TextArea.tsx
+++ b/packages/arco-lib/src/components/TextArea.tsx
@@ -24,6 +24,7 @@ const exampleProperties: Static<typeof TextAreaPropsSpec> = {
   error: false,
   size: 'default',
   autoSize: true,
+  updateWhenDefaultValueChanges:false
 };
 
 const options = {
@@ -48,7 +49,13 @@ const options = {
 };
 
 export const TextArea = implementRuntimeComponent(options)(props => {
-  const { getElement, customStyle, callbackMap, mergeState } = props;
+  const {
+    getElement,
+    updateWhenDefaultValueChanges,
+    customStyle,
+    callbackMap,
+    mergeState,
+  } = props;
   const { defaultValue, ...cProps } = getComponentProps(props);
   const [value, setValue] = useState(defaultValue);
   const ref = useRef<RefInputType | null>(null);
@@ -59,6 +66,13 @@ export const TextArea = implementRuntimeComponent(options)(props => {
       getElement(ele);
     }
   }, [getElement, ref]);
+
+  useEffect(() => {
+    if (updateWhenDefaultValueChanges) {
+      setValue(defaultValue);
+      mergeState({ value: defaultValue });
+    }
+  }, [defaultValue, updateWhenDefaultValueChanges]);
 
   return (
     <BaseTextArea

--- a/packages/arco-lib/src/generated/types/Form.ts
+++ b/packages/arco-lib/src/generated/types/Form.ts
@@ -36,5 +36,25 @@ export const FormControlPropsSpec = {
   colon: Type.Boolean({
     title: 'Colon',
     category: Category.Style,
-  })
+  }),
+  labelCol: Type.Object(
+    {
+      span: Type.Number(),
+      offset: Type.Number(),
+    },
+    {
+      title: 'Label Col',
+      category: Category.Layout,
+    }
+  ),
+  wrapperCol: Type.Object(
+    {
+      span: Type.Number(),
+      offset: Type.Number(),
+    },
+    {
+      title: 'Wrapper Col',
+      category: Category.Layout,
+    }
+  ),
 };

--- a/packages/arco-lib/src/generated/types/Input.ts
+++ b/packages/arco-lib/src/generated/types/Input.ts
@@ -15,7 +15,7 @@ export const InputPropsSpec = {
   }),
   updateWhenDefaultValueChanges: Type.Boolean({
     title: 'Update When Default Value Changes',
-    category: 'Basic',
+    category: Category.Basic,
   }),
   allowClear: Type.Boolean({
     title: 'Allow Clear',

--- a/packages/arco-lib/src/generated/types/Input.ts
+++ b/packages/arco-lib/src/generated/types/Input.ts
@@ -13,6 +13,10 @@ export const InputPropsSpec = {
     category: Category.Basic,
     weight: 1,
   }),
+  updateWhenDefaultValueChanges: Type.Boolean({
+    title: 'Update When Default Value Changes',
+    category: 'Basic',
+  }),
   allowClear: Type.Boolean({
     title: 'Allow Clear',
     category: Category.Basic,

--- a/packages/arco-lib/src/generated/types/Link.ts
+++ b/packages/arco-lib/src/generated/types/Link.ts
@@ -18,7 +18,7 @@ export const LinkPropsSpec = {
     category: Category.Style,
     description: 'Whether to hide background when hover'
   }),
-  status: StringUnion(['success', 'warning', 'error'], {
+  status: StringUnion(['default','success', 'warning', 'error'], {
     title: 'Status',
     category: Category.Style,
   }),

--- a/packages/arco-lib/src/generated/types/Slider.ts
+++ b/packages/arco-lib/src/generated/types/Slider.ts
@@ -1,0 +1,56 @@
+import { Type } from '@sinclair/typebox';
+import { StringUnion } from '../../sunmao-helper';
+import { Category } from '../../constants/category';
+import { CORE_VERSION, CoreWidgetName } from '@sunmao-ui/editor-sdk';
+
+export const SliderPropsSpec = {
+    min: Type.Number({
+        title: 'Min',
+        category: Category.Basic
+    }),
+    max: Type.Number({
+        title: 'Max',
+        category: Category.Basic
+    }),
+    disabled: Type.Boolean({
+        title: 'Disabled',
+        category: Category.Basic
+    }),
+    toolTipPosition: Type.Optional(StringUnion(['top', 'tl', 'tr', 'bottom', 'bl', 'br', 'left', 'lt', 'lb', 'right', 'rt', 'rb'], {
+        category: Category.Layout,
+        title: 'Tooltip Position'
+    })),
+    vertical: Type.Boolean({
+        title: 'Vertical',
+        category: Category.Layout,
+    }),
+    tooltipVisible: Type.Boolean({
+        title: 'Show Tooltip',
+        category: Category.Behavior
+    }),
+    range: Type.Boolean({
+        title: 'Enable Range',
+        category: Category.Behavior
+    }),
+    step: Type.Number({
+        title: 'Step',
+        category: Category.Behavior
+    }),
+    showTicks: Type.Boolean({
+        title: 'Show Ticks',
+        category: Category.Behavior
+    }),
+    marks: Type.Object({}, {
+        title: 'Marks',
+        widget: `${CORE_VERSION}/${CoreWidgetName.RecordField}`,
+        category: Category.Behavior
+    }),
+    onlyMarkValue: Type.Boolean({
+        title: 'Only Mark Value',
+        category: Category.Behavior
+    }),
+    reverse: Type.Boolean({
+        title: 'Reverse',
+        category: Category.Behavior
+    })
+};

--- a/packages/arco-lib/src/generated/types/TextArea.ts
+++ b/packages/arco-lib/src/generated/types/TextArea.ts
@@ -19,6 +19,10 @@ export const TextAreaPropsSpec = {
     title: 'Disabled',
     category: Category.Basic,
   }),
+  updateWhenDefaultValueChanges: Type.Boolean({
+    title: 'Update When Default Value Changes',
+    category: Category.Basic,
+  }),
   size: StringUnion(['default', 'mini', 'small', 'large'], {
     title: 'Size',
     category: Category.Style,

--- a/packages/arco-lib/src/lib.ts
+++ b/packages/arco-lib/src/lib.ts
@@ -36,6 +36,7 @@ import { Tabs } from './components/Tabs';
 import { FormControl } from './components/Form/FormControl';
 import { Descriptions } from './components/Descriptions';
 import { Row, Col } from './components/Grid'
+import { Slider } from './components/Slider';
 
 import './style.css';
 
@@ -77,7 +78,8 @@ export const components: SunmaoLib['components'] = [
   Tabs,
   FormControl,
   Descriptions,
-  Row, Col
+  Row, Col,
+  Slider
 ];
 export const traits: SunmaoLib['traits'] = [];
 export const modules: SunmaoLib['modules'] = [];


### PR DESCRIPTION
1. feat(slider): add slider component
2. refactor(formcontrol): In a previous commit I removed the grid layout property from formcontrol, which was undesirable as it was still needed in most cases, so it was restored
3. feat(link): add a default target style to the link
4. feat(input,textarea): Add the updateWhenDefaultValueChanges property to change the default value accordingly