### PR TITLE
Feat/component searching

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@chakra-ui/icons": "^1.0.15",
     "@chakra-ui/react": "^1.7.1",
+    "@choc-ui/chakra-autocomplete": "^4.22.0",
     "@emotion/css": "^11.7.1",
     "@emotion/react": "^11.1.1",
     "@sinclair/typebox": "^0.21.2",

--- a/packages/editor/src/components/StructureTree/ComponentItemView.tsx
+++ b/packages/editor/src/components/StructureTree/ComponentItemView.tsx
@@ -38,7 +38,6 @@ export const ComponentItemView: React.FC<Props> = props => {
   const expandIcon = (
     <IconButton
       margin="auto"
-      ml="-5"
       flex="0 0 auto"
       aria-label="showChildren"
       size="xs"
@@ -92,7 +91,7 @@ export const ComponentItemView: React.FC<Props> = props => {
     <Box
       id={`tree-item-${id}`}
       width="full"
-      padding="1"
+      paddingY="1"
       onMouseOver={() => setIsHover(true)}
       onMouseLeave={() => setIsHover(false)}
       onDragStart={_onDragStart}
@@ -103,7 +102,7 @@ export const ComponentItemView: React.FC<Props> = props => {
       onClick={onClick}
     >
       {highlightBackground}
-      <HStack width="full" justify="space-between" spacing="0">
+      <HStack width="full" justify="space-between" spacing="0" paddingLeft={noChevron ? '6' : '0'}>
         {noChevron ? null : expandIcon}
         <Text
           cursor="pointer"
@@ -111,6 +110,7 @@ export const ComponentItemView: React.FC<Props> = props => {
           whiteSpace="nowrap"
           textOverflow="ellipsis"
           fontSize="sm"
+          title={title}
         >
           {title}
         </Text>

--- a/packages/editor/src/components/StructureTree/StructureTree.tsx
+++ b/packages/editor/src/components/StructureTree/StructureTree.tsx
@@ -103,7 +103,9 @@ export const StructureTree: React.FC<Props> = props => {
         </AutoComplete>
       </VStack>
       <Box width="full" flex={1} minHeight={0} overflowY="auto" overflowX="hidden">
-        {componentEles.length > 0 ? componentEles : <Placeholder services={services} />}
+        {componentEles.length > 0 ? componentEles : (<Box padding="4">
+          <Placeholder services={services} />
+        </Box>)}
       </Box>
     </VStack>
   );

--- a/packages/editor/src/components/StructureTree/StructureTree.tsx
+++ b/packages/editor/src/components/StructureTree/StructureTree.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useEffect } from 'react';
+import React, { useMemo, useRef, useCallback } from 'react';
 import { ComponentSchema } from '@sunmao-ui/core';
 import { Box, Text, VStack } from '@chakra-ui/react';
 import { ComponentTreeWrapper } from './ComponentTree';
@@ -7,6 +7,14 @@ import { resolveApplicationComponents } from '../../utils/resolveApplicationComp
 import ErrorBoundary from '../ErrorBoundary';
 import { EditorServices } from '../../types';
 import { CORE_VERSION, CoreComponentName } from '@sunmao-ui/shared';
+import {
+  AutoComplete,
+  AutoCompleteInput,
+  AutoCompleteItem,
+  AutoCompleteList,
+  type Item
+} from '@choc-ui/chakra-autocomplete';
+import { css } from '@emotion/css';
 
 export type ChildrenMap = Map<string, SlotsMap>;
 type SlotsMap = Map<string, ComponentSchema[]>;
@@ -18,9 +26,31 @@ type Props = {
   services: EditorServices;
 };
 
+const AutoCompleteStyle = css`
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+`;
+
 export const StructureTree: React.FC<Props> = props => {
-  const { components, selectedComponentId, onSelectComponent, services } = props;
+  const { components, onSelectComponent, services } = props;
   const wrapperRef = useRef<HTMLDivElement>(null);
+  
+  const onSelectOption = useCallback(({item}: {item: Item}) => {
+    onSelectComponent(item.value);
+  }, [onSelectComponent]);
+  const onSelected = useCallback((selectedId)=> {
+    if (selectedId) {
+      // wait the component tree to be expanded
+      setTimeout(()=> {
+        wrapperRef.current
+          ?.querySelector(`#tree-item-${selectedId}`)
+          ?.scrollIntoView({
+            block: 'nearest',
+            inline: 'nearest'
+          });
+      });
+    }
+  }, []);
 
   const realComponents = useMemo(() => {
     return components.filter(
@@ -40,28 +70,41 @@ export const StructureTree: React.FC<Props> = props => {
         slot={undefined}
         childrenMap={childrenMap}
         onSelectComponent={onSelectComponent}
+        onSelected={onSelected}
         services={services}
         isAncestorDragging={false}
         depth={0}
       />
     ));
-  }, [realComponents, onSelectComponent, services]);
-
-  useEffect(() => {
-    wrapperRef.current
-      ?.querySelector(`#tree-item-${selectedComponentId}`)
-      ?.scrollIntoView({
-        block: 'nearest',
-        inline: 'nearest'
-      });
-  }, [selectedComponentId]);
+  }, [realComponents, onSelectComponent, onSelected, services]);
 
   return (
-    <VStack ref={wrapperRef} height='full' spacing="2" padding="4" alignItems="start" overflowX='hidden' overflowY="auto">
-      <Text fontSize="lg" fontWeight="bold" mb="0.5rem">
-        Components
-      </Text>
-      {componentEles.length > 0 ? componentEles : <Placeholder services={services} />}
+    <VStack
+      ref={wrapperRef}
+      height="full"
+      paddingY="4"
+      alignItems="start"
+      overflowX="hidden"
+      overflowY="auto"
+    >
+      <VStack alignItems="start" width="full" paddingX="4">
+        <Text fontSize="lg" fontWeight="bold">
+          Components
+        </Text>
+        <AutoComplete openOnFocus  onSelectOption={onSelectOption} className={AutoCompleteStyle}>
+          <AutoCompleteInput placeholder="please input the component id" size="md" variant="filled" marginTop={0} />
+          <AutoCompleteList>
+            {realComponents.map(component => (
+              <AutoCompleteItem key={component.id} value={component.id}>
+                {component.id}
+              </AutoCompleteItem>
+          ))}
+          </AutoCompleteList>
+        </AutoComplete>
+      </VStack>
+      <Box width="full" flex={1} minHeight={0} overflowY="auto" overflowX="hidden">
+        {componentEles.length > 0 ? componentEles : <Placeholder services={services} />}
+      </Box>
     </VStack>
   );
 };

--- a/packages/editor/src/components/StructureTree/StructureTree.tsx
+++ b/packages/editor/src/components/StructureTree/StructureTree.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useCallback } from 'react';
+import React, { useState, useMemo, useRef, useCallback } from 'react';
 import { ComponentSchema } from '@sunmao-ui/core';
 import { Box, Text, VStack } from '@chakra-ui/react';
 import { ComponentTreeWrapper } from './ComponentTree';
@@ -12,7 +12,7 @@ import {
   AutoCompleteInput,
   AutoCompleteItem,
   AutoCompleteList,
-  type Item
+  type Item,
 } from '@choc-ui/chakra-autocomplete';
 import { css } from '@emotion/css';
 
@@ -32,25 +32,34 @@ const AutoCompleteStyle = css`
 `;
 
 export const StructureTree: React.FC<Props> = props => {
+  const [search, setSearch] = useState('');
   const { components, onSelectComponent, services } = props;
   const wrapperRef = useRef<HTMLDivElement>(null);
-  
-  const onSelectOption = useCallback(({item}: {item: Item}) => {
-    onSelectComponent(item.value);
-  }, [onSelectComponent]);
-  const onSelected = useCallback((selectedId)=> {
+
+  const onSelectOption = useCallback(
+    ({ item }: { item: Item }) => {
+      onSelectComponent(item.value);
+      setSearch(item.value);
+    },
+    [onSelectComponent]
+  );
+  const onSelected = useCallback(selectedId => {
     if (selectedId) {
       // wait the component tree to be expanded
-      setTimeout(()=> {
-        wrapperRef.current
-          ?.querySelector(`#tree-item-${selectedId}`)
-          ?.scrollIntoView({
-            block: 'nearest',
-            inline: 'nearest'
-          });
+      setTimeout(() => {
+        wrapperRef.current?.querySelector(`#tree-item-${selectedId}`)?.scrollIntoView({
+          block: 'nearest',
+          inline: 'nearest',
+        });
       });
     }
   }, []);
+  const onSearchChange: React.ChangeEventHandler<HTMLInputElement> = useCallback(
+    event => {
+      setSearch(event.target.value);
+    },
+    []
+  );
 
   const realComponents = useMemo(() => {
     return components.filter(
@@ -91,21 +100,36 @@ export const StructureTree: React.FC<Props> = props => {
         <Text fontSize="lg" fontWeight="bold">
           Components
         </Text>
-        <AutoComplete openOnFocus  onSelectOption={onSelectOption} className={AutoCompleteStyle}>
-          <AutoCompleteInput placeholder="please input the component id" size="md" variant="filled" marginTop={0} />
+        <AutoComplete
+          openOnFocus
+          onSelectOption={onSelectOption}
+          className={AutoCompleteStyle}
+        >
+          <AutoCompleteInput
+            value={search}
+            placeholder="please input the component id"
+            size="md"
+            variant="filled"
+            marginTop={0}
+            onChange={onSearchChange}
+          />
           <AutoCompleteList>
             {realComponents.map(component => (
               <AutoCompleteItem key={component.id} value={component.id}>
                 {component.id}
               </AutoCompleteItem>
-          ))}
+            ))}
           </AutoCompleteList>
         </AutoComplete>
       </VStack>
       <Box width="full" flex={1} minHeight={0} overflowY="auto" overflowX="hidden">
-        {componentEles.length > 0 ? componentEles : (<Box padding="4">
-          <Placeholder services={services} />
-        </Box>)}
+        {componentEles.length > 0 ? (
+          componentEles
+        ) : (
+          <Box padding="4">
+            <Placeholder services={services} />
+          </Box>
+        )}
       </Box>
     </VStack>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1841,6 +1841,13 @@
   dependencies:
     "@chakra-ui/utils" "1.9.1"
 
+"@choc-ui/chakra-autocomplete@^4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@choc-ui/chakra-autocomplete/-/chakra-autocomplete-4.22.0.tgz#540b9f561309cc7a64e9fbd4f44ff30336189aa7"
+  integrity sha512-jP1IBM8Xtm7iNs4mB1ky/HRFpJQeNUDbVwA2CQ/UZyPHsoMGbo6dH2iHofaE1H4KuGPJV1gWvjmQ6o/uMYeT0g==
+  dependencies:
+    react-nanny "^2.9.0"
+
 "@ctrl/tinycolor@^3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz#c3c5ae543c897caa9c2a68630bed355be5f9990f"
@@ -9328,6 +9335,11 @@ react-markdown@^7.1.0:
     unified "^10.0.0"
     unist-util-visit "^4.0.0"
     vfile "^5.0.0"
+
+react-nanny@^2.9.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/react-nanny/-/react-nanny-2.14.0.tgz#c53afa8cd9612ca0eee57a35e0d38b65f76445a4"
+  integrity sha512-lX+SNWlpbIhN4h3zJQAtRqr7AXwldmgKxJ8e+eChFvMQISsZmHaR2SJujb3u1S6fpC5pUnYKsdbtwZXUG/4Qjw==
 
 react-refresh@^0.10.0:
   version "0.10.0"


### PR DESCRIPTION
## Implement
1. Change the `selectedComponentId` when selecting the autocomplete option.
2. The selected component item triggers the `onSelected` event to expand the nodes on the path.
3. Wait until the nodes are expanded, and scroll to the selected component item.

## Preview
https://user-images.githubusercontent.com/25414733/169256379-f7ad95c5-8cf8-4e74-9099-2e078b9b64d7.mov