### PR TITLE
fix: add ignoreEvalError flag in eval function to make nested expression can be evaled partially.

### DIFF
--- a/packages/runtime/__tests__/expression.spec.ts
+++ b/packages/runtime/__tests__/expression.spec.ts
@@ -102,4 +102,17 @@ describe('evalExpression function', () => {
       })
     ).toEqual('{{wrongExp}}');
   });
+
+  it('can partially eval nest expression, even when some error happens', () => {
+    expect(
+      stateManager.maskedEval('{{text}} {{{{ $moduleId }}__state0.value}}', {
+        scopeObject: {
+          $moduleId: 'myModule',
+          text: 'hello',
+        },
+        noConsoleError: true,
+        ignoreEvalError: true
+      })
+    ).toEqual(`hello {{myModule__state0.value}}`);
+  });
 });

--- a/packages/runtime/src/components/_internal/ModuleRenderer.tsx
+++ b/packages/runtime/src/components/_internal/ModuleRenderer.tsx
@@ -37,12 +37,13 @@ const ModuleRendererContent = React.forwardRef<
   Props & { moduleSpec: ImplementedRuntimeModule }
 >((props, ref) => {
   const { moduleSpec, properties, handlers, evalScope, services, app } = props;
-  const evalOptions = { evalListItem: true, scopeObject: evalScope };
-  const moduleId = services.stateManager.maskedEval(props.id, evalOptions) as
-    | string
-    | ExpressionError;
+  const moduleId = services.stateManager.maskedEval(props.id, {
+    evalListItem: true,
+    scopeObject: evalScope,
+  }) as string | ExpressionError;
 
   function evalObject<T extends Record<string, any>>(obj: T): T {
+    const evalOptions = { evalListItem: true, scopeObject: evalScope };
     return services.stateManager.mapValuesDeep({ obj }, ({ value }) => {
       if (typeof value === 'string') {
         return services.stateManager.maskedEval(value, evalOptions);
@@ -79,6 +80,7 @@ const ModuleRendererContent = React.forwardRef<
           ...evaledProperties,
           $moduleId: moduleId,
         },
+        ignoreEvalError: true,
         overrideScope: true,
         fallbackWhenError: exp => exp,
       }
@@ -128,7 +130,10 @@ const ModuleRendererContent = React.forwardRef<
     _handlers.forEach(h => {
       const moduleEventHandler = ({ fromId, eventType }: Record<string, string>) => {
         if (eventType === h.type && fromId === moduleId) {
-          const evaledHandler = services.stateManager.deepEval(h, evalOptions);
+          const evaledHandler = services.stateManager.deepEval(h, {
+            evalListItem: true,
+            scopeObject: evalScope,
+          });
           services.apiService.send('uiMethod', {
             componentId: evaledHandler.componentId,
             name: evaledHandler.method.name,
@@ -145,7 +150,13 @@ const ModuleRendererContent = React.forwardRef<
         services.apiService.off('moduleEvent', h);
       });
     };
-  }, [evalScope, handlers, moduleId, services.apiService, services.stateManager]);
+  }, [
+    evalScope,
+    handlers,
+    moduleId,
+    services.apiService,
+    services.stateManager,
+  ]);
 
   const result = useMemo(() => {
     // Must init components' state, otherwise store cannot listen these components' state changing

--- a/packages/runtime/src/services/StateManager.ts
+++ b/packages/runtime/src/services/StateManager.ts
@@ -7,7 +7,13 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import LocalizedFormat from 'dayjs/plugin/localizedFormat';
 import { isProxy, reactive, toRaw } from '@vue/reactivity';
 import { watch } from '../utils/watchReactivity';
-import { isNumeric, parseExpression, consoleError, ConsoleType, type ExpChunk } from '@sunmao-ui/shared';
+import {
+  isNumeric,
+  parseExpression,
+  consoleError,
+  ConsoleType,
+  ExpChunk,
+} from '@sunmao-ui/shared';
 
 dayjs.extend(relativeTime);
 dayjs.extend(isLeapYear);
@@ -19,7 +25,9 @@ type EvalOptions = {
   scopeObject?: Record<string, any>;
   overrideScope?: boolean;
   fallbackWhenError?: (exp: string) => any;
-  noConsoleError?: boolean
+  noConsoleError?: boolean;
+  // when ignoreEvalError is true, the eval process will continue after error happens in nests expression.
+  ignoreEvalError?: boolean;
 };
 
 // TODO: use web worker
@@ -35,7 +43,7 @@ export class ExpressionError extends Error {
   }
 }
 
-export type StateManagerInterface = InstanceType<typeof StateManager>
+export type StateManagerInterface = InstanceType<typeof StateManager>;
 
 export class StateManager {
   store = reactive<Record<string, any>>({});
@@ -55,25 +63,33 @@ export class StateManager {
       return expChunk;
     }
 
-    const { scopeObject = {}, overrideScope = false } = options;
+    const { scopeObject = {}, overrideScope = false, ignoreEvalError = false } = options;
     const evalText = expChunk.map(ex => this.evalExp(ex, { scopeObject })).join('');
 
-    // eslint-disable-next-line no-useless-call, no-new-func
-    const evaled = new Function(
-      'store, dependencies, scopeObject',
-      // trim leading space and newline
-      `with(store) { with(dependencies) { with(scopeObject) { return ${evalText.replace(
-        /^\s+/g,
-        ''
-      )} } } }`
-    ).call(
-      null,
-      overrideScope ? {} : this.store,
-      overrideScope ? {} : this.dependencies,
-      scopeObject
-    );
+    try {
+      // eslint-disable-next-line no-useless-call, no-new-func
+      const evaled = new Function(
+        'store, dependencies, scopeObject',
+        // trim leading space and newline
+        `with(store) { with(dependencies) { with(scopeObject) { return ${evalText.replace(
+          /^\s+/g,
+          ''
+        )} } } }`
+      ).call(
+        null,
+        overrideScope ? {} : this.store,
+        overrideScope ? {} : this.dependencies,
+        scopeObject
+      );
 
-    return evaled;
+      return evaled;
+    } catch (error) {
+      if (ignoreEvalError) {
+        // convert it to expression and return
+        return `{{${evalText}}}`;
+      }
+      throw error;
+    }
   };
 
   maskedEval(raw: string, options: EvalOptions = {}): unknown | ExpressionError {


### PR DESCRIPTION
The original issue is the expression like `{{text + {{ $moduleId }}__state0.value}}` cannot be compiled correctly.
It shoule be compiled to  `{{'Hello world!' + myModule__state0.value}}`. However, it will return itself when error happens  during complilation.
So I add a `ignoreEvalError` flag, to enable expression to be partially compiled, ignoring the error parts.
Even though, this pr cannot solve the original issue entirely. The orginal expression should be rewrite to  `{{text}} {{{{ $moduleId }}__state0.value}}` to ensure the `text` and `{{ $moduleId }}__state0.value` are not in the same chunk of expression.