### PR TITLE
fix: trait form is covered by section titles

### DIFF
--- a/packages/editor/src/components/ComponentForm/GeneralTraitFormList/AddTraitButton.tsx
+++ b/packages/editor/src/components/ComponentForm/GeneralTraitFormList/AddTraitButton.tsx
@@ -49,7 +49,7 @@ export const AddTraitButton: React.FC<Props> = props => {
         >
           Add Trait
         </MenuButton>
-        <MenuList zIndex={2}>{menuItems}</MenuList>
+        <MenuList zIndex={100}>{menuItems}</MenuList>
       </Menu>
     </Box>
   );


### PR DESCRIPTION
### Bug

If I click the button 'Add Trait', the popup form will be covered by some section titles with higher z index values.
<img width="333" alt="image" src="https://user-images.githubusercontent.com/27533910/173324881-4e9c2a8a-b08e-4cfc-b48d-136f81dfb93d.png">

### Fix

Change the z index value of that form to 100. '100' is equal to the z-index of section titles.
<img width="516" alt="image" src="https://user-images.githubusercontent.com/27533910/173325206-40bdec5a-623a-4aed-9f05-fef28c177212.png">

Effect applied this fix:
<img width="335" alt="image" src="https://user-images.githubusercontent.com/27533910/173325557-4a1fdcc2-692c-4c2e-bee9-70f6f05f5185.png">

