### PR TITLE
feat(arco): enable to customize button content of Dropdown component

### DIFF
--- a/packages/arco-lib/src/components/Dropdown.tsx
+++ b/packages/arco-lib/src/components/Dropdown.tsx
@@ -15,6 +15,7 @@ const DropdownStateSpec = Type.Object({
 });
 
 const exampleProperties: Static<typeof DropdownPropsSpec> = {
+  text: 'Click',
   dropdownType: 'default',
   trigger: 'click',
   position: 'bl',
@@ -51,7 +52,7 @@ export const Dropdown = implementRuntimeComponent({
     events: ['onClickMenuItem', 'onVisibleChange', 'onButtonClick'],
   },
 })(props => {
-  const { elementRef, slotsElements, callbackMap, mergeState } = props;
+  const { text, elementRef, slotsElements, callbackMap, mergeState } = props;
   const cProps = getComponentProps(props);
   const { list, dropdownType, autoAlignPopupWidth, ...restProps } = cProps;
   const typeMap = {
@@ -90,7 +91,11 @@ export const Dropdown = implementRuntimeComponent({
       triggerProps={{ autoAlignPopupMinWidth: autoAlignPopupWidth }}
     >
       <div ref={elementRef}>
-        {slotsElements.trigger ? slotsElements.trigger({}) : <Button>Click</Button>}
+        {slotsElements.trigger ? (
+          slotsElements.trigger({})
+        ) : (
+          <Button>{text || null}</Button>
+        )}
       </div>
     </Dropdown>
   );

--- a/packages/arco-lib/src/generated/types/Dropdown.ts
+++ b/packages/arco-lib/src/generated/types/Dropdown.ts
@@ -7,6 +7,10 @@ export const DropdownPropsSpec = {
     title: 'Type',
     category: Category.Basic,
   }),
+  text: Type.String({
+    title: 'Text',
+    category: Category.Basic,
+  }),
   position: StringUnion(['top', 'tl', 'tr', 'bottom', 'bl', 'br'], {
     title: 'Position',
     category: Category.Layout,
@@ -23,13 +27,13 @@ export const DropdownPropsSpec = {
     title: 'Default Visible',
     category: Category.Basic,
   }),
-  autoAlignPopupWidth:Type.Boolean({
-    title:'Auto Align Popup Width',
+  autoAlignPopupWidth: Type.Boolean({
+    title: 'Auto Align Popup Width',
     category: Category.Basic,
   }),
-  unmountOnExit:Type.Boolean({
-    title:'Destroy On Hide',
-    category: Category.Behavior
+  unmountOnExit: Type.Boolean({
+    title: 'Destroy On Hide',
+    category: Category.Behavior,
   }),
   list: Type.Array(
     Type.Object({
@@ -43,7 +47,7 @@ export const DropdownPropsSpec = {
     {
       title: 'List',
       category: Category.Basic,
-      widget:'core/v1/expression',
+      widget: 'core/v1/expression',
       weight: 10,
     }
   ),


### PR DESCRIPTION
### motivation
Currently, the text of the Dropdown component is fixed with the text 'Click'.
<img width="866" alt="image" src="https://user-images.githubusercontent.com/27533910/173488878-c7f58956-99cb-438f-9cc3-d95dc46fdea9.png">
<img width="138" alt="image" src="https://user-images.githubusercontent.com/27533910/173488615-134f2832-9a41-44d2-8cbd-4802cf43fae9.png">
This component isn't helpful unless the content is customisable.

### effect of PR
<img width="356" alt="image" src="https://user-images.githubusercontent.com/27533910/173489226-80cf6d77-3c2f-401a-a920-6ec4874344d4.png">
<img width="208" alt="image" src="https://user-images.githubusercontent.com/27533910/173489094-c8883aee-14a7-41a2-a891-cfa72934ca00.png">
