### PR TITLE
feat(arco): expose 'setInputValue' method for Input and Textarea

### DIFF
--- a/packages/arco-lib/src/components/Input.tsx
+++ b/packages/arco-lib/src/components/Input.tsx
@@ -40,7 +40,11 @@ const options = {
   spec: {
     properties: InputPropsSpec,
     state: InputStateSpec,
-    methods: {},
+    methods: {
+      setInputValue: Type.Object({
+        value: Type.String(),
+      }),
+    },
     slots: {
       addAfter: { slotProps: Type.Object({}) },
       prefix: { slotProps: Type.Object({}) },
@@ -53,7 +57,14 @@ const options = {
 };
 
 export const Input = implementRuntimeComponent(options)(props => {
-  const { getElement, slotsElements, customStyle, callbackMap, mergeState } = props;
+  const {
+    getElement,
+    slotsElements,
+    customStyle,
+    callbackMap,
+    mergeState,
+    subscribeMethods,
+  } = props;
 
   const { updateWhenDefaultValueChanges, defaultValue, ...cProps } =
     getComponentProps(props);
@@ -77,8 +88,18 @@ export const Input = implementRuntimeComponent(options)(props => {
       mergeState({ value });
       callbackMap?.onChange?.();
     },
-    [mergeState, callbackMap]
+    [setValue, mergeState, callbackMap]
   );
+
+  useEffect(() => {
+    subscribeMethods({
+      setInputValue({ value }) {
+        setValue(value);
+        mergeState({ value });
+        callbackMap?.onChange?.();
+      },
+    });
+  }, [setValue, mergeState, callbackMap, subscribeMethods]);
 
   return (
     <BaseInput

--- a/packages/arco-lib/src/components/TextArea.tsx
+++ b/packages/arco-lib/src/components/TextArea.tsx
@@ -42,7 +42,11 @@ export const TextArea = implementRuntimeComponent({
   spec: {
     properties: TextAreaPropsSpec,
     state: TextAreaStateSpec,
-    methods: {},
+    methods: {
+      setInputValue: Type.Object({
+        value: Type.String(),
+      }),
+    },
     slots: {},
     styleSlots: ['TextArea'],
     events: ['onChange', 'onBlur', 'onFocus', 'onClear', 'onPressEnter'],
@@ -54,6 +58,7 @@ export const TextArea = implementRuntimeComponent({
     customStyle,
     callbackMap,
     mergeState,
+    subscribeMethods,
   } = props;
   const { defaultValue, ...cProps } = getComponentProps(props);
   const [value, setValue] = useStateValue(
@@ -69,6 +74,16 @@ export const TextArea = implementRuntimeComponent({
       getElement(ele);
     }
   }, [getElement, ref]);
+
+  useEffect(() => {
+    subscribeMethods({
+      setInputValue({ value }) {
+        setValue(value);
+        mergeState({ value });
+        callbackMap?.onChange?.();
+      },
+    });
+  }, [setValue, mergeState, callbackMap, subscribeMethods]);
 
   return (
     <BaseTextArea


### PR DESCRIPTION
### motivation
The Input and Textarea components (arco design) don't have a setInputValue method as Chakra's input component does. But I think this method is very helpful for other components to control the value of the Input component.

<img width="361" alt="image" src="https://user-images.githubusercontent.com/27533910/174087020-b108f53d-37bf-4533-97ef-06461d0db6a0.png">

### effect of PR
<img width="361" alt="image" src="https://user-images.githubusercontent.com/27533910/174086866-4d5c92a5-4174-4034-90f5-d5123b03f57b.png">
<img width="364" alt="image" src="https://user-images.githubusercontent.com/27533910/174092328-e7ea31f4-ec60-4bca-9490-ad576d007612.png">



