### PR TITLE
fix:  css style string is parsed to char array accidentally

### DIFF
--- a/packages/arco-lib/src/components/Table/Table.tsx
+++ b/packages/arco-lib/src/components/Table/Table.tsx
@@ -509,6 +509,10 @@ export const Table = implementRuntimeComponent({
           ? record => {
               return {
                 onClick(event: React.ChangeEvent<HTMLButtonElement>) {
+                  // When user clicks a radio or checkbox, the 'rowClicked' event should not be triggered.
+                  const OPERATION_COLUMN_CLASS_SELECTOR = '.arco-table-operation';
+                  if (event.target.closest(OPERATION_COLUMN_CLASS_SELECTOR) !== null)
+                    return;
                   const tr = event.target.closest('tr');
                   const tbody = tr?.parentNode;
                   if (tbody) {

--- a/packages/editor/src/components/ComponentForm/StyleTraitForm/StyleTraitForm.tsx
+++ b/packages/editor/src/components/ComponentForm/StyleTraitForm/StyleTraitForm.tsx
@@ -152,7 +152,7 @@ export const StyleTraitForm: React.FC<Props> = props => {
       };
 
       const changeCssProperties = (newCss: PartialCSSProperties) => {
-        const newCssProperties = Object.assign({}, style, newCss);
+        const newCssProperties = Object.assign({}, cssProperties, newCss);
         const newStyles = produce(styles, draft => {
           draft[i].cssProperties = newCssProperties;
         });


### PR DESCRIPTION
### bug fix: CSS style string is parsed to char array accidentally

bug reproduction:
1. add CSS style 'padding: none;' to a style trait.
2. change the width or height value to '100px'.
<img width="338" alt="image" src="https://user-images.githubusercontent.com/27533910/174636976-689aa843-7f32-4a84-b565-ec6389000710.png">
3. Then the schema's corresponding part changes to 
<img width="405" alt="image" src="https://user-images.githubusercontent.com/27533910/174637387-69ea4720-35d1-4eb6-9e11-bfce5029fc07.png">


### feat (arco-design): don't trigger the onRowClick method when clicking the table's radios or checkbox
#### motivation:
Currently, when a user clicks the table's radio or checkbox, the onRowClick method is also triggered.  In the general case, the row selection operation (clicking a checkbox) should be separated from clicking a row item. 
<img width="814" alt="image" src="https://user-images.githubusercontent.com/27533910/174638431-a4ff5989-b700-4194-8b99-4f302338ae75.png">
Thinking about a use case: a user clicks a row to open a model which shows detailed messages about it. The user doesn't want to open the dialogue when clicking the checkbox to select this row.
