### PR TITLE
fix: increase the hidden trait style priority

### DIFF
--- a/packages/editor-sdk/src/components/Widgets/ObjectField.tsx
+++ b/packages/editor-sdk/src/components/Widgets/ObjectField.tsx
@@ -21,7 +21,7 @@ export const ObjectField: React.FC<WidgetProps<ObjectFieldWidgetOptionsType>> = 
 
   const properties = Object.keys(spec.properties || {});
   return (
-    <VStack spacing='0' paddingLeft='3'>
+    <VStack spacing="0" paddingLeft={level > 0 ? 3 : 0}>
       {properties.map(name => {
         const subSpec = (spec.properties || {})[name] as WidgetProps['spec'];
 

--- a/packages/editor/src/components/DataSource/DataForm/DataForm.tsx
+++ b/packages/editor/src/components/DataSource/DataForm/DataForm.tsx
@@ -4,12 +4,18 @@ import { ComponentSchema } from '@sunmao-ui/core';
 import { ObjectField, mergeWidgetOptionsIntoSpec } from '@sunmao-ui/editor-sdk';
 import { EditorServices } from '../../../types';
 import { genOperation } from '../../../operations';
+import { css } from '@emotion/css';
 
 interface Props {
   datasource: ComponentSchema;
   services: EditorServices;
   traitType: string;
 }
+
+const LabelStyle = css`
+  font-weight: normal;
+  font-size: 14px;
+`;
 
 export const DataForm: React.FC<Props> = props => {
   const { datasource, services, traitType } = props;
@@ -46,14 +52,22 @@ export const DataForm: React.FC<Props> = props => {
     e.stopPropagation();
   };
 
-  useEffect(()=> {
+  useEffect(() => {
     setName(datasource.id);
   }, [datasource.id]);
 
   return (
-    <VStack p="2" spacing="2" background="gray.50" onKeyDown={onKeyDown}>
+    <VStack
+      p="2"
+      spacing="2"
+      background="gray.50"
+      alignItems="stretch"
+      onKeyDown={onKeyDown}
+    >
       <FormControl>
-        <FormLabel>Name</FormLabel>
+        <FormLabel>
+          <span className={LabelStyle}>Name</span>
+        </FormLabel>
         <Input
           value={name}
           onChange={e => {

--- a/packages/runtime/src/traits/core/Hidden.tsx
+++ b/packages/runtime/src/traits/core/Hidden.tsx
@@ -27,7 +27,7 @@ export default implementRuntimeTrait({
       return {
         props: {
           customStyle: {
-            content: hidden ? 'display: none' : '',
+            content: hidden ? '&&&& { display: none }' : '',
           },
         },
       };


### PR DESCRIPTION
The hidden trait's `display: none` would be overwritten by the component styles or the style trait.

I use the `&&&& { display: none }` to increase its priority which is greater than the style trait's `&&&`.