### PR TITLE
fix: increase the hidden trait style priority

### DIFF
--- a/packages/runtime/src/traits/core/Hidden.tsx
+++ b/packages/runtime/src/traits/core/Hidden.tsx
@@ -27,7 +27,7 @@ export default implementRuntimeTrait({
       return {
         props: {
           customStyle: {
-            content: hidden ? 'display: none' : '',
+            content: hidden ? '&&&& { display: none }' : '',
           },
         },
       };


### PR DESCRIPTION
The hidden trait's `display: none` would be overwritten by the component styles or the style trait.

I use the `&&&& { display: none }` to increase its priority which is greater than the style trait's `&&&`.