### PR TITLE
fix(ExpressionEditor): fix the error happening when evaledValue is a function

### DIFF
--- a/packages/editor-sdk/src/components/Form/ExpressionEditor.tsx
+++ b/packages/editor-sdk/src/components/Form/ExpressionEditor.tsx
@@ -304,7 +304,7 @@ export const BaseExpressionEditor = React.forwardRef<
 
 export type ExpressionEditorProps = BaseExpressionEditorProps & {
   compactOptions?: ExpressionEditorStyleProps;
-  evaledValue?: any;
+  evaledValue?: { value: any };
   error?: string | null;
 };
 export type ExpressionEditorHandle = BaseExpressionEditorHandle;
@@ -414,9 +414,9 @@ export const ExpressionEditor = React.forwardRef<
           whiteSpace="pre-wrap"
         >
           <Box fontWeight="bold" marginBottom="4px">
-            {error ? 'Error' : getTypeString(evaledValue)}
+            {error ? 'Error' : getTypeString(evaledValue?.value)}
           </Box>
-          {error || JSON.stringify(evaledValue, null, 2)}
+          {error || JSON.stringify(evaledValue?.value, null, 2)}
         </Box>
       ) : null}
       {showModal && (

--- a/packages/editor-sdk/src/components/Widgets/ExpressionWidget.tsx
+++ b/packages/editor-sdk/src/components/Widgets/ExpressionWidget.tsx
@@ -155,7 +155,7 @@ export const ExpressionWidget: React.FC<WidgetProps<ExpressionWidgetType>> = pro
     return getCode(value);
   }, [value]);
   const [defs, setDefs] = useState<any>();
-  const [evaledValue, setEvaledValue] = useState<any>(null);
+  const [evaledValue, setEvaledValue] = useState<any>({ value: null });
   const [error, setError] = useState<string | null>(null);
   const editorRef = useRef<ExpressionEditorHandle>(null);
   const validate = useMemo(() => ajv.compile(spec), [spec]);
@@ -193,7 +193,9 @@ export const ExpressionWidget: React.FC<WidgetProps<ExpressionWidgetType>> = pro
           }
         }
 
-        setEvaledValue(result);
+        setEvaledValue({
+          value: result,
+        });
         setError(null);
       } catch (err) {
         setError(String(err));


### PR DESCRIPTION
When inputting the expression like `{{state.value.concat}}` would make the component form crash, because when passing a function as a value to React's `setState`, React would execute the function instead of setting it as a value.