### PR TITLE
fix(arco/Menu): fix a bug where the collapse button doesn't work

### DIFF
--- a/packages/arco-lib/src/components/Menu.tsx
+++ b/packages/arco-lib/src/components/Menu.tsx
@@ -57,9 +57,12 @@ export const Menu = implementRuntimeComponent({
   const {
     items = [],
     defaultActiveKey,
+    collapse,
+    hasCollapseButton,
     updateWhenDefaultValueChanges,
     ...cProps
   } = getComponentProps(props);
+
   const [activeKey, setActiveKey] = useStateValue(
     defaultActiveKey ?? 0,
     mergeState,
@@ -88,6 +91,8 @@ export const Menu = implementRuntimeComponent({
         });
         callbackMap?.onClick?.();
       }}
+      collapse={hasCollapseButton ? undefined : collapse}
+      hasCollapseButton={hasCollapseButton}
       {...cProps}
     >
       {items.map(item => (

--- a/packages/arco-lib/src/generated/types/Menu.ts
+++ b/packages/arco-lib/src/generated/types/Menu.ts
@@ -46,11 +46,24 @@ export const MenuPropsSpec = {
   autoOpen: Type.Boolean({
     title: 'Auto Open',
     description: 'Whether to expand all multi-level menus by default',
-    category: Category.Basic,
+    category: Category.Behavior,
+  }),
+  hasCollapseButton: Type.Boolean({
+    title: 'Collapse Button',
+    category: Category.Behavior,
+    conditions: [{ key: 'mode', value: 'vertical' }],
   }),
   collapse: Type.Boolean({
     title: 'Collapse',
-    category: Category.Style,
+    category: Category.Behavior,
+    conditions: [
+      {
+        and: [
+          { key: 'mode', value: 'vertical' },
+          { key: 'hasCollapseButton', value: false },
+        ],
+      },
+    ],
   }),
   // accordion: Type.Boolean({
   //   category: Category.Style,
@@ -58,14 +71,11 @@ export const MenuPropsSpec = {
   ellipsis: Type.Boolean({
     title: 'Ellipsis',
     description: 'Whether the horizontal menu automatically collapses when it overflows',
-    category: Category.Basic,
+    category: Category.Behavior,
+    conditions: [{ key: 'mode', value: 'vertical' }],
   }),
   autoScrollIntoView: Type.Boolean({
     title: 'Auto Scroll Into View',
-    category: Category.Basic,
-  }),
-  hasCollapseButton: Type.Boolean({
-    title: 'Collapse Button',
-    category: Category.Basic,
+    category: Category.Behavior,
   }),
 };


### PR DESCRIPTION
When `hasCollapseButton` is false, it is in `uncontrolled mode` and the collapse button is clicked to collapse the menu, when it is true, the `collapse property` controls whether it is collapsed or not.