### PR TITLE
fix(traitForm): hide create slot trait button in menu

### DIFF
--- a/packages/editor/src/components/ComponentForm/GeneralTraitFormList/AddTraitButton.tsx
+++ b/packages/editor/src/components/ComponentForm/GeneralTraitFormList/AddTraitButton.tsx
@@ -10,7 +10,7 @@ import {
 } from '@chakra-ui/react';
 import { RegistryInterface } from '@sunmao-ui/runtime';
 import React, { useMemo } from 'react';
-import { ignoreTraitsList } from '../../../constants';
+import { hideCreateTraitsList } from '../../../constants';
 import { ComponentSchema } from '@sunmao-ui/core';
 
 type Props = {
@@ -30,7 +30,9 @@ export const AddTraitButton: React.FC<Props> = props => {
     [component]
   );
   const traitTypes = useMemo(() => {
-    return registry.getAllTraitTypes().filter(type => !ignoreTraitsList.includes(type));
+    return registry
+      .getAllTraitTypes()
+      .filter(type => !hideCreateTraitsList.includes(type));
   }, [registry]);
 
   const menuItems = traitTypes.map(type => {

--- a/packages/editor/src/constants/index.ts
+++ b/packages/editor/src/constants/index.ts
@@ -4,14 +4,16 @@ import { CORE_VERSION, CoreTraitName } from '@sunmao-ui/shared';
 
 export const unremovableTraits = [`${CORE_VERSION}/${CoreTraitName.Slot}`];
 
-export const ignoreTraitsList = [
+export const hideCreateTraitsList = [
   `${CORE_VERSION}/${CoreTraitName.Event}`,
   `${CORE_VERSION}/${CoreTraitName.Style}`,
   `${CORE_VERSION}/${CoreTraitName.Fetch}`,
+  `${CORE_VERSION}/${CoreTraitName.Slot}`,
 ];
 
 export const hasSpecialFormTraitList = [
-  ...ignoreTraitsList,
+  `${CORE_VERSION}/${CoreTraitName.Event}`,
+  `${CORE_VERSION}/${CoreTraitName.Style}`,
   `${CORE_VERSION}/${CoreTraitName.Fetch}`,
 ];
 


### PR DESCRIPTION
# Problem
If user add slot trait ny clicking add trait button, the component will disappear, because the `parentId` of slot trait is empty.

To avoid this bug, I decide to hide add slot trait button in menu. User can add slot trait only by creating or moving component by operation.