### PR TITLE
fix(ImplWrapper): deep compare slotContext in memo

### DIFF
--- a/packages/runtime/__tests__/ImplWrapper/mockSchema.ts
+++ b/packages/runtime/__tests__/ImplWrapper/mockSchema.ts
@@ -84,6 +84,55 @@ export const HiddenTraitSchema: Application = {
   },
 };
 
+export const ParentRerenderSchema: Application = {
+  version: 'sunmao/v1',
+  kind: 'Application',
+  metadata: {
+    name: 'some App',
+  },
+  spec: {
+    components: [
+      {
+        id: 'input',
+        type: 'test/v1/input',
+        properties: {
+          defaultValue: '',
+        },
+        traits: [],
+      },
+      {
+        id: 'stack6',
+        type: 'core/v1/stack',
+        properties: {
+          spacing: 12,
+          direction: 'horizontal',
+          align: 'auto',
+          wrap: '{{!!input.value}}',
+          justify: 'flex-start',
+        },
+        traits: [],
+      },
+      {
+        id: 'tester',
+        type: 'test/v1/tester',
+        properties: {},
+        traits: [
+          {
+            type: 'core/v1/slot',
+            properties: {
+              container: {
+                id: 'stack6',
+                slot: 'content',
+              },
+              ifCondition: true,
+            },
+          },
+        ],
+      },
+    ],
+  },
+};
+
 export const MergeStateSchema: Application = {
   version: 'sunmao/v1',
   kind: 'Application',

--- a/packages/runtime/src/components/_internal/ImplWrapper/ImplWrapper.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/ImplWrapper.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ImplWrapperProps } from '../../../types';
 import { shallowCompare } from '@sunmao-ui/shared';
 import { UnmountImplWrapper } from './UnmountImplWrapper';
+import { isEqual } from 'lodash';
 
 export const ImplWrapper = React.memo<ImplWrapperProps>(
   UnmountImplWrapper,
@@ -10,20 +11,19 @@ export const ImplWrapper = React.memo<ImplWrapperProps>(
     const nextChildren = nextProps.childrenMap[nextProps.component.id]?._grandChildren;
     const prevComponent = prevProps.component;
     const nextComponent = nextProps.component;
-    let isEqual = false;
+    let isComponentEqual = false;
 
     if (prevChildren && nextChildren) {
-      isEqual = shallowCompare(prevChildren, nextChildren);
+      isComponentEqual = shallowCompare(prevChildren, nextChildren);
     } else if (prevChildren === nextChildren) {
-      isEqual = true;
+      isComponentEqual = true;
     }
-
     return (
-      isEqual &&
+      isComponentEqual &&
       prevComponent === nextComponent &&
       // TODO: keep ImplWrapper memorized and get slot props from store
       shallowCompare(prevProps.slotProps, nextProps.slotProps) &&
-      shallowCompare(prevProps.slotContext, nextProps.slotContext)
+      isEqual(prevProps.slotContext, nextProps.slotContext)
     );
   }
 );


### PR DESCRIPTION
# Problem
Every time a parent component updates, its `slotContext.renderSet` will be a new `Set`. This causes `shallowCompare` fail to check two same `slotContext`, leading to the fact that every time a parent updates, its children will update too, no matter its children changes or not.

I replace `shallowCompare` to `isEuqual` to deep compare to change. Since `slotContext` is not very big, I think the trade off of performance is acceptable.

![截屏2022-07-27 下午3 50 58](https://user-images.githubusercontent.com/12260952/181192496-6603fb48-96f9-457e-99e0-9d25839076e0.png)
