### PR TITLE
feat(RecordWidget): allow use the widget for object

### DIFF
--- a/packages/editor-sdk/src/components/Form/ArrayTable.tsx
+++ b/packages/editor-sdk/src/components/Form/ArrayTable.tsx
@@ -147,7 +147,7 @@ export const ArrayTable: React.FC<ArrayTableProps> = props => {
               />
             ))
           ) : (
-            <Tr span>
+            <Tr>
               <Td colSpan={(displayedKeys.length || 1) + 2} textAlign="center">
                 No Data
               </Td>


### PR DESCRIPTION
Let the `RecordWidget` use other widgets to display the object and array type properties when explicitly declaring the widget in the spec. 

When the spec is `Type.Record(Type.String(), Type.Object(...))`, generating the default value by the spec which read from `spec.patternProperties.['^.*$']` instead of using the empty string as the default value.