### PR TITLE
fix(mask): fix wrong mask position

### DIFF
--- a/packages/editor/src/components/EditorMaskWrapper/EditorMaskManager.ts
+++ b/packages/editor/src/components/EditorMaskWrapper/EditorMaskManager.ts
@@ -117,8 +117,9 @@ export class EditorMaskManager {
   }
 
   private observeContainerResize() {
-    this.containerResizeObserver = new ResizeObserver(e => {
-      this.maskContainerRect = e[0].contentRect;
+    this.containerResizeObserver = new ResizeObserver(() => {
+      this.maskContainerRect =
+        this.maskContainerRef.current?.getBoundingClientRect() || null;
     });
 
     this.containerResizeObserver.observe(this.maskContainerRef.current!);


### PR DESCRIPTION
`contentRect` behaves differently with `getBoundingClientReact`, and may be deprecated in the future. So we use `getBoundingClientReact` back.