### PR TITLE
fix(editor): pasted component's children disappear after id changes

### DIFF
--- a/packages/editor/__tests__/operations/component.spec.ts
+++ b/packages/editor/__tests__/operations/component.spec.ts
@@ -1,19 +1,47 @@
 import { AppModel } from '../../src/AppModel/AppModel';
 import { ComponentId } from '../../src/AppModel/IAppModel';
 import { registry } from '../services';
-import { AppSchema } from './mock';
+import { AppSchema, PasteComponentWithChildrenSchema } from './mock';
 import { genOperation } from '../../src/operations';
 
-describe('Component operations', ()=> {
-    it('Change component id', ()=> {
-        const appModel = new AppModel(AppSchema.spec.components, registry);
+describe('Component operations', () => {
+  it('Change component id', () => {
+    const appModel = new AppModel(AppSchema.spec.components, registry);
 
-        expect(appModel.getComponentById('text1' as ComponentId).id).toBe('text1');
-        const operation = genOperation(registry, 'modifyComponentId', {
-            componentId: 'text1',
-            newId: 'text2',
-        });
-        operation.do(appModel);
-        expect(appModel.getComponentById('text2' as ComponentId).id).toBe('text2');
-    })
-})
+    expect(appModel.getComponentById('text1' as ComponentId)?.id).toBe('text1');
+    const operation = genOperation(registry, 'modifyComponentId', {
+      componentId: 'text1',
+      newId: 'text2',
+    });
+    operation.do(appModel);
+    expect(appModel.getComponentById('text2' as ComponentId)?.id).toBe('text2');
+  });
+
+  it(`Paste component with children and the children's slot trait is correct`, () => {
+    const appModel = new AppModel(
+      PasteComponentWithChildrenSchema.spec.components,
+      registry
+    );
+
+    const pasteComponent = [
+      appModel.getComponentById('stack5' as ComponentId)!.toSchema(),
+      appModel.getComponentById('text6' as ComponentId)!.toSchema(),
+    ];
+    const operation = genOperation(registry, 'pasteComponent', {
+      parentId: 'stack3',
+      slot: 'content',
+      component: new AppModel(pasteComponent, registry).getComponentById(
+        'stack5' as ComponentId
+      )!,
+      copyTimes: 0,
+    });
+    operation.do(appModel);
+    expect(appModel.getComponentById('text6_copy0' as ComponentId)?.parent?.id).toBe(
+      'stack5_copy0'
+    );
+    expect(
+      appModel.getComponentById('text6_copy0' as ComponentId)?.traits[0].rawProperties
+        .container.id
+    ).toBe('stack5_copy0');
+  });
+});

--- a/packages/editor/__tests__/operations/mock.ts
+++ b/packages/editor/__tests__/operations/mock.ts
@@ -15,3 +15,71 @@ export const AppSchema: Application = {
     ],
   },
 };
+export const PasteComponentWithChildrenSchema: Application = {
+  version: 'sunmao/v1',
+  kind: 'Application',
+  metadata: {
+    name: 'some App',
+  },
+  spec: {
+    components: [
+      {
+        id: 'stack3',
+        type: 'core/v1/stack',
+        properties: {
+          spacing: 12,
+          direction: 'horizontal',
+          align: 'auto',
+          wrap: false,
+          justify: 'flex-start',
+        },
+        traits: [],
+      },
+      {
+        id: 'stack5',
+        type: 'core/v1/stack',
+        properties: {
+          spacing: 12,
+          direction: 'horizontal',
+          align: 'auto',
+          wrap: false,
+          justify: 'flex-start',
+        },
+        traits: [
+          {
+            type: 'core/v1/slot',
+            properties: {
+              container: {
+                id: 'stack3',
+                slot: 'content',
+              },
+              ifCondition: true,
+            },
+          },
+        ],
+      },
+      {
+        id: 'text6',
+        type: 'core/v1/text',
+        properties: {
+          value: {
+            raw: 'text',
+            format: 'plain',
+          },
+        },
+        traits: [
+          {
+            type: 'core/v1/slot',
+            properties: {
+              container: {
+                id: 'stack5',
+                slot: 'content',
+              },
+              ifCondition: true,
+            },
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/packages/editor/src/AppModel/ComponentModel.ts
+++ b/packages/editor/src/AppModel/ComponentModel.ts
@@ -68,18 +68,11 @@ export class ComponentModel implements IComponentModel {
     this.type = schema.type as ComponentType;
     this.spec = this.registry.getComponentByType(this.type) as any;
 
-    this.traits = schema.traits.map(
-      t => new TraitModel(t, this.registry, this.appModel, this)
-    );
+    this.traits = schema.traits.map(t => new TraitModel(t, this.registry, this));
     this.genStateExample();
     this.parentId = this._slotTrait?.rawProperties.container.id;
     this.parentSlot = this._slotTrait?.rawProperties.container.slot;
-    this.properties = new FieldModel(
-      schema.properties,
-      this.spec.spec.properties,
-      this.appModel,
-      this
-    );
+    this.properties = new FieldModel(schema.properties, this, this.spec.spec.properties);
   }
 
   get slots() {
@@ -174,7 +167,7 @@ export class ComponentModel implements IComponentModel {
 
   addTrait(traitType: TraitType, properties: Record<string, unknown>): ITraitModel {
     const traitSchema = genTrait(traitType, properties);
-    const trait = new TraitModel(traitSchema, this.registry, this.appModel, this);
+    const trait = new TraitModel(traitSchema, this.registry, this);
     this.traits.push(trait);
     this._isDirty = true;
     this.genStateExample();
@@ -243,7 +236,7 @@ export class ComponentModel implements IComponentModel {
     }
     this._isDirty = true;
     this.appModel.changeComponentMapId(oldId, newId);
-    this.appModel.emitter.emit('idChange', { oldId, newId });
+    this.appModel.traverseAllFields(field => field.changeReferenceId(oldId, newId));
 
     return this;
   }

--- a/packages/editor/src/AppModel/FieldModel.ts
+++ b/packages/editor/src/AppModel/FieldModel.ts
@@ -7,14 +7,12 @@ import { flattenDeep, isArray, isObject } from 'lodash';
 import { isExpression } from '../validator/utils';
 import {
   ComponentId,
-  IAppModel,
   IComponentModel,
   ITraitModel,
   IFieldModel,
   ModuleId,
   RefInfo,
   ASTNode,
-  AppModelEventType,
 } from './IAppModel';
 import escodegen from 'escodegen';
 import { JSONSchema7 } from 'json-schema';
@@ -38,13 +36,11 @@ export class FieldModel implements IFieldModel {
 
   constructor(
     value: unknown,
-    public spec?: JSONSchema7 & CustomOptions,
-    private appModel?: IAppModel,
     private componentModel?: IComponentModel,
+    public spec?: JSONSchema7 & CustomOptions,
     private traitModel?: ITraitModel
   ) {
     this.update(value);
-    this.appModel?.emitter.on('idChange', this.onReferenceIdChange.bind(this));
   }
 
   get rawValue() {
@@ -81,11 +77,10 @@ export class FieldModel implements IFieldModel {
           } else {
             newValue = new FieldModel(
               value[key],
+              this.componentModel,
               (this.spec?.properties?.[key] || this.spec?.items) as
                 | (JSONSchema7 & CustomOptions)
                 | undefined,
-              this.appModel,
-              this.componentModel,
               this.traitModel
             );
           }
@@ -254,7 +249,7 @@ export class FieldModel implements IFieldModel {
     return path.slice(1).join('.');
   }
 
-  private onReferenceIdChange({ oldId, newId }: AppModelEventType['idChange']) {
+  changeReferenceId(oldId: ComponentId, newId: ComponentId) {
     if (!this.componentModel) {
       return;
     }

--- a/packages/editor/src/AppModel/IAppModel.ts
+++ b/packages/editor/src/AppModel/IAppModel.ts
@@ -62,6 +62,7 @@ export interface IAppModel {
   changeComponentMapId(oldId: ComponentId, newId: ComponentId): void;
   _bindComponentToModel(component: IComponentModel): void;
   traverseTree(cb: (c: IComponentModel) => void): void;
+  traverseAllFields(cb: (f: IFieldModel) => void): void;
 }
 
 export interface IModuleModel {
@@ -145,4 +146,5 @@ export interface IFieldModel {
   traverse: (cb: (f: IFieldModel, key: string) => void) => void;
   // ids of used components in the expression
   refComponentInfos: Record<ComponentId | ModuleId, RefInfo>;
+  changeReferenceId(oldId: ComponentId, newId: ComponentId): void;
 }

--- a/packages/editor/src/AppModel/TraitModel.ts
+++ b/packages/editor/src/AppModel/TraitModel.ts
@@ -6,7 +6,6 @@ import {
   ITraitModel,
   IFieldModel,
   TraitId,
-  IAppModel,
 } from './IAppModel';
 import { FieldModel } from './FieldModel';
 import { genTrait } from './utils';
@@ -24,7 +23,6 @@ export class TraitModel implements ITraitModel {
   constructor(
     trait: TraitSchema,
     private registry: RegistryInterface,
-    private appModel: IAppModel,
     public parent: IComponentModel
   ) {
     this.schema = trait;
@@ -35,9 +33,8 @@ export class TraitModel implements ITraitModel {
 
     this.properties = new FieldModel(
       trait.properties,
-      this.spec.spec.properties,
-      this.appModel,
       this.parent,
+      this.spec.spec.properties,
       this
     );
   }

--- a/packages/editor/src/services/EditorStore.ts
+++ b/packages/editor/src/services/EditorStore.ts
@@ -79,6 +79,7 @@ export class EditorStore {
       schemaValidator: observable.ref,
       setComponents: action,
       setDragOverComponentId: action,
+      setHoverComponentId: action,
     });
 
     this.eventBus.on('selectComponent', id => {


### PR DESCRIPTION
# How to reproduce this bug.
1. Create a component that has children.
2. Copy and paste this component to other components.
3. Change the id of the new pasted component.
4. The new pasted component's children will disappear.

# Reason
The reason for this bug is that `FieldModel` will update itself when receiving the `ChangeId` event emitted by `AppModel`. But the pasting operation will create a new `AppModel` which consists of a copy of pasted components. The pasted components' `FieldModel` only listen to their own `AppModel`'s event. However, the `ChangeId` event is emitted by the old `AppModel`.So the pasted components' slot trait FieldModel can not receive `ChangeId` event, thus they will not update their parent id in slot trait.

# Solution
Don't use eventBus to `changeReferenceId`. Trigger `changeReferenceId` imperatively, so that FieldModel will run `changeReferenceId` even if its `AppModel` changed.