### PR TITLE
build(all): build bundle with React.createElement

### DIFF
--- a/packages/arco-lib/package.json
+++ b/packages/arco-lib/package.json
@@ -72,7 +72,7 @@
     "@sunmao-ui/core": "^0.7.0",
     "@sunmao-ui/runtime": "^0.7.0",
     "lodash": "^4.17.21",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "16.x || 17.x",
+    "react-dom": "16.x || 17.x"
   }
 }

--- a/packages/chakra-ui-lib/package.json
+++ b/packages/chakra-ui-lib/package.json
@@ -59,7 +59,7 @@
     "@sunmao-ui/runtime": "^0.7.0",
     "@sunmao-ui/shared": "^0.2.0",
     "lodash": "^4.17.21",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "16.x || 17.x",
+    "react-dom": "16.x || 17.x"
   }
 }

--- a/packages/editor-sdk/package.json
+++ b/packages/editor-sdk/package.json
@@ -63,8 +63,8 @@
   },
   "peerDependencies": {
     "ajv": "^8.8.2",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "16.x || 17.x",
+    "react-dom": "16.x || 17.x",
     "tern": "^0.24.3"
   }
 }

--- a/packages/editor-sdk/tsconfig.json
+++ b/packages/editor-sdk/tsconfig.json
@@ -19,7 +19,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "baseUrl": "./",
-    "jsx": "react-jsx",
+    "jsx": "react",
     "rootDir": "src",
     "declaration": true,
     "declarationDir": "lib"

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -89,7 +89,8 @@
   },
   "peerDependencies": {
     "react": "16.x || 17.x",
-    "react-dom": "16.x || 17.x"
+    "react-dom": "16.x || 17.x",
+    "@emotion/react": "^11.8.1"
   },
   "husky": {
     "hooks": {

--- a/packages/editor/src/main.tsx
+++ b/packages/editor/src/main.tsx
@@ -1,4 +1,4 @@
-import { StrictMode } from 'react';
+import React, { StrictMode } from 'react';
 import ReactDOM from 'react-dom';
 import { RegistryInterface } from '@sunmao-ui/runtime';
 import { sunmaoChakraUILib, widgets as chakraWidgets } from '@sunmao-ui/chakra-ui-lib';

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -19,7 +19,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "baseUrl": "./",
-    "jsx": "react-jsx",
+    "jsx": "react",
     "rootDir": "src",
     "declaration": true,
     "declarationDir": "lib"

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -73,7 +73,7 @@
     "vite": "^3.0.8"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "16.x || 17.x",
+    "react-dom": "16.x || 17.x"
   }
 }

--- a/packages/runtime/react-import.ts
+++ b/packages/runtime/react-import.ts
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export { React };

--- a/packages/runtime/src/components/core/Iframe.tsx
+++ b/packages/runtime/src/components/core/Iframe.tsx
@@ -2,7 +2,7 @@ import { implementRuntimeComponent } from '../../utils/buildKit';
 import { Type } from '@sinclair/typebox';
 import { CORE_VERSION, CoreComponentName, StringUnion } from '@sunmao-ui/shared';
 import { css } from '@emotion/css';
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 
 export default implementRuntimeComponent({
   version: CORE_VERSION,

--- a/packages/runtime/src/components/core/List.tsx
+++ b/packages/runtime/src/components/core/List.tsx
@@ -4,6 +4,7 @@ import { LIST_ITEM_EXP, LIST_ITEM_INDEX_EXP } from '../../constants';
 import { implementRuntimeComponent } from '../../utils/buildKit';
 import { ImplWrapper } from '../_internal/ImplWrapper';
 import { formatSlotKey } from '../_internal/ImplWrapper/hooks/useSlotChildren';
+import React from 'react';
 
 const PropsSpec = Type.Object({
   listData: Type.Array(Type.Record(Type.String(), Type.String()), {

--- a/packages/runtime/src/components/core/ModuleContainer.tsx
+++ b/packages/runtime/src/components/core/ModuleContainer.tsx
@@ -1,6 +1,7 @@
 import { implementRuntimeComponent } from '../../utils/buildKit';
 import { ModuleRenderSpec, CORE_VERSION, CoreComponentName } from '@sunmao-ui/shared';
 import { ModuleRenderer } from '../_internal/ModuleRenderer';
+import React from 'react';
 
 export default implementRuntimeComponent({
   version: CORE_VERSION,

--- a/packages/runtime/src/components/core/Router/component.tsx
+++ b/packages/runtime/src/components/core/Router/component.tsx
@@ -1,4 +1,4 @@
-import {
+import React, {
   cloneElement,
   Fragment,
   isValidElement,
@@ -21,10 +21,7 @@ import {
   RouterCtx,
   useNavigate,
 } from './hooks';
-import {
-  UIServices,
-  ChildrenMap,
-} from '../../../types';
+import { UIServices, ChildrenMap } from '../../../types';
 import { RuntimeComponentSchema } from '@sunmao-ui/core';
 
 export type RouteLikeElement = PropsWithChildren<{
@@ -87,7 +84,7 @@ export const Switch: React.FC<SwitchProps> = props => {
   const [loc, naviagte] = useLocation();
 
   const routes = useMemo(() => {
-    let defaultPath: string | undefined = undefined;
+    let defaultPath: string | undefined;
     const result = switchPolicy.map(
       ({ type, path, slotId, href, default: _default, exact, strict, sensitive }) => {
         const children = slotsElements[slotId];
@@ -166,7 +163,7 @@ export const Switch: React.FC<SwitchProps> = props => {
     mergeState({
       route: loc,
     });
-    () => {
+    return () => {
       mergeState({
         route: undefined,
       });

--- a/packages/runtime/src/components/core/Router/index.tsx
+++ b/packages/runtime/src/components/core/Router/index.tsx
@@ -2,6 +2,7 @@ import { Static, Type } from '@sinclair/typebox';
 import { implementRuntimeComponent } from '../../../utils/buildKit';
 import { Switch } from './component';
 import { CORE_VERSION } from '@sunmao-ui/shared';
+import React from 'react';
 
 export enum RouteType {
   REDIRECT = 'REDIRECT',

--- a/packages/runtime/src/components/core/Text.tsx
+++ b/packages/runtime/src/components/core/Text.tsx
@@ -2,6 +2,7 @@ import { Type } from '@sinclair/typebox';
 import _Text, { TextPropertySpec } from '../_internal/Text';
 import { implementRuntimeComponent } from '../../utils/buildKit';
 import { CORE_VERSION, CoreComponentName } from '@sunmao-ui/shared';
+import React from 'react';
 
 const StateSpec = Type.Object({
   value: Type.String(),

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -19,7 +19,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "baseUrl": "./",
-    "jsx": "react-jsx",
+    "jsx": "react",
     "rootDir": "src",
     "declaration": true,
     "declarationDir": "lib"

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -19,7 +19,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "baseUrl": "./",
-    "jsx": "react-jsx",
+    "jsx": "react",
     "rootDir": "src",
     "declaration": true,
     "declarationDir": "lib"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2718,6 +2718,13 @@
   dependencies:
     "@emotion/memoize" "^0.8.0"
 
+"@emotion/is-prop-valid@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz#7f2d35c97891669f7e276eb71c83376a5dc44c83"
+  integrity sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==
+  dependencies:
+    "@emotion/memoize" "^0.8.0"
+
 "@emotion/memoize@0.7.4":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
@@ -2780,6 +2787,18 @@
   integrity sha512-OiTkRgpxescko+M51tZsMq7Puu/KP55wMT8BgpcXVG2hqXc0Vo0mfymJ/Uj24Hp0i083ji/o0aLddh08UEjq8w==
 
 "@emotion/styled@^11.0.0", "@emotion/styled@^11.8.1":
+  version "11.10.4"
+  resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.10.4.tgz#e93f84a4d54003c2acbde178c3f97b421fce1cd4"
+  integrity sha512-pRl4R8Ez3UXvOPfc2bzIoV8u9P97UedgHS4FPX594ntwEuAMA114wlaHvOK24HB48uqfXiGlYIZYCxVJ1R1ttQ==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    "@emotion/babel-plugin" "^11.10.0"
+    "@emotion/is-prop-valid" "^1.2.0"
+    "@emotion/serialize" "^1.1.0"
+    "@emotion/use-insertion-effect-with-fallbacks" "^1.0.0"
+    "@emotion/utils" "^1.2.0"
+
+"@emotion/styled@^11.6.0":
   version "11.10.4"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.10.4.tgz#e93f84a4d54003c2acbde178c3f97b421fce1cd4"
   integrity sha512-pRl4R8Ez3UXvOPfc2bzIoV8u9P97UedgHS4FPX594ntwEuAMA114wlaHvOK24HB48uqfXiGlYIZYCxVJ1R1ttQ==


### PR DESCRIPTION
Build `runtime` and `editor` package with `React.createElement` instead of `jsx` to make sunmao compatiable with React 16.