### PR TITLE
fix(editor): page freezes when fetch response is too large

### DIFF
--- a/packages/editor/src/components/CodeEditor/CodeEditor.tsx
+++ b/packages/editor/src/components/CodeEditor/CodeEditor.tsx
@@ -17,7 +17,16 @@ export const CodeEditor: React.FC<{
   onChange?: (v: string) => void;
   onBlur?: (v: string) => void;
   needRerenderAfterMount?: boolean;
-}> = ({ defaultCode, mode, needRerenderAfterMount, className, onChange, onBlur }) => {
+  readOnly?: boolean;
+}> = ({
+  defaultCode,
+  mode,
+  needRerenderAfterMount,
+  className,
+  onChange,
+  onBlur,
+  readOnly,
+}) => {
   const valueRef = useRef(defaultCode);
   const [rerenderFlag, setRerenderFlag] = useState(0);
   const style = css`
@@ -61,6 +70,7 @@ export const CodeEditor: React.FC<{
           },
         },
         theme: 'ayu-mirage',
+        readOnly,
       }}
     />
   );

--- a/packages/editor/src/components/DataSource/ApiForm/Response.tsx
+++ b/packages/editor/src/components/DataSource/ApiForm/Response.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   HStack,
   Flex,
@@ -32,15 +32,21 @@ const stringify = (value: any): string => {
 };
 
 export const Response: React.FC<Props> = props => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
   const data = useMemo(() => {
     return stringify(props.data);
   }, [props.data]);
   const error = useMemo(() => {
     return stringify(props.error);
   }, [props.error]);
-
   return props.data || props.error || props.loading ? (
-    <Accordion defaultIndex={0} allowToggle border="solid" borderColor="inherit">
+    <Accordion
+      onChange={i => setIsOpen(i === 0)}
+      allowToggle
+      reduceMotion
+      border="solid"
+      borderColor="inherit"
+    >
       <AccordionItem>
         <h2>
           <AccordionButton>
@@ -57,7 +63,7 @@ export const Response: React.FC<Props> = props => {
         </h2>
         <AccordionPanel pb={4} padding={0} height="250px">
           <Flex alignItems="center" justifyContent="center" height="100%">
-            {props.loading ? (
+            {props.loading || !isOpen ? (
               <Spinner />
             ) : (
               <CodeEditor
@@ -70,6 +76,7 @@ export const Response: React.FC<Props> = props => {
                   json: true,
                 }}
                 defaultCode={error || data}
+                readOnly
               />
             )}
           </Flex>


### PR DESCRIPTION
Only render response when Accordion is open, so that the page will not freeze every time.