### PR TITLE
fix(editor): prevent pasting component when cursor in input components

### DIFF
--- a/packages/editor/src/components/KeyboardEventWrapper.tsx
+++ b/packages/editor/src/components/KeyboardEventWrapper.tsx
@@ -15,6 +15,8 @@ type Props = {
   services: EditorServices;
 };
 
+const KeyboardEventWrapperId = 'keyboard-event-wrapper';
+
 export const KeyboardEventWrapper: React.FC<Props> = ({
   selectedComponentId,
   components,
@@ -36,7 +38,8 @@ export const KeyboardEventWrapper: React.FC<Props> = ({
     return component?.slots[0] || '';
   }
 
-  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if ((e.target as Element).id !== KeyboardEventWrapperId) return;
     switch (e.key) {
       case 'Delete':
       case 'Backspace':
@@ -124,7 +127,7 @@ export const KeyboardEventWrapper: React.FC<Props> = ({
 
   return (
     <Box
-      id="keyboard-event-wrapper"
+      id={KeyboardEventWrapperId}
       className={style}
       width="100%"
       height="100%"


### PR DESCRIPTION
# Background
When user tries to ctrl+v a text in a input component, the pasting component operation will be triggered and components will be pasted into input's slot. This is not expected.

Only when cursor is not in input, should the keyboard events be handled.