### PR TITLE
Arco/fix

### DIFF
--- a/packages/arco-lib/src/components/Link.tsx
+++ b/packages/arco-lib/src/components/Link.tsx
@@ -44,6 +44,9 @@ export const Link = implementRuntimeComponent({
       content: {
         slotProps: Type.Object({}),
       },
+      icon: {
+        slotProps: Type.Object({}),
+      },
     },
     styleSlots: ['content'],
     events: ['onClick'],
@@ -58,6 +61,7 @@ export const Link = implementRuntimeComponent({
       ref={elementRef}
       status={statusMap[status]}
       className={css(customStyle?.content)}
+      icon={slotsElements.icon?.({})}
       onClick={() => {
         callbackMap?.onClick?.();
       }}

--- a/packages/arco-lib/src/components/Link.tsx
+++ b/packages/arco-lib/src/components/Link.tsx
@@ -9,6 +9,7 @@ const LinkPropsSpec = Type.Object(BaseLinkPropsSpec);
 const LinkStateSpec = Type.Object({});
 
 const exampleProperties: Static<typeof LinkPropsSpec> = {
+  asLink: true,
   disabled: false,
   hoverable: true,
   status: 'default',
@@ -45,19 +46,26 @@ export const Link = implementRuntimeComponent({
       },
     },
     styleSlots: ['content'],
-    events: [],
+    events: ['onClick'],
   },
 })(props => {
-  const { content, status, openInNewPage, ...cProps } = getComponentProps(props);
-  const { elementRef, customStyle, slotsElements } = props;
+  const { asLink, content, status, openInNewPage, href, ...cProps } =
+    getComponentProps(props);
+  const { elementRef, customStyle, slotsElements, callbackMap } = props;
 
   return (
     <BaseLink
       ref={elementRef}
       status={statusMap[status]}
       className={css(customStyle?.content)}
+      onClick={() => {
+        callbackMap?.onClick?.();
+      }}
       {...cProps}
-      target={openInNewPage ? '_blank' : '_self'}
+      {...(asLink && {
+        target: openInNewPage ? '_blank' : '_self',
+        href,
+      })}
     >
       {slotsElements.content ? slotsElements.content({}) : content}
     </BaseLink>

--- a/packages/arco-lib/src/components/Select.tsx
+++ b/packages/arco-lib/src/components/Select.tsx
@@ -31,7 +31,7 @@ export const Select = implementRuntimeComponent({
       labelInValue: false,
       loading: false,
       showSearch: false,
-      unmountOnExit: false,
+      unmountOnExit: true,
       showTitle: false,
       options: [
         { value: 'Beijing', text: 'Beijing' },
@@ -42,6 +42,12 @@ export const Select = implementRuntimeComponent({
       size: 'default',
       error: false,
       updateWhenDefaultValueChanges: false,
+      autoFixPosition: false,
+      autoAlignPopupMinWidth: false,
+      autoAlignPopupWidth: true,
+      autoFitPosition: false,
+      position: 'bottom',
+      mountToBody: true,
     },
     annotations: {
       category: 'Data Entry',
@@ -76,6 +82,12 @@ export const Select = implementRuntimeComponent({
     retainInputValue,
     updateWhenDefaultValueChanges,
     showTitle,
+    mountToBody,
+    autoFixPosition,
+    autoAlignPopupMinWidth,
+    autoAlignPopupWidth,
+    autoFitPosition,
+    position,
     ...cProps
   } = getComponentProps(props);
 
@@ -126,6 +138,13 @@ export const Select = implementRuntimeComponent({
       }}
       value={value}
       {...cProps}
+      triggerProps={{
+        autoAlignPopupMinWidth,
+        autoAlignPopupWidth,
+        autoFitPosition,
+        autoFixPosition,
+        position,
+      }}
       showSearch={showSearch}
       filterOption={(inputValue, option) =>
         option.props.value.toLowerCase().indexOf(inputValue.toLowerCase()) >= 0 ||
@@ -140,6 +159,9 @@ export const Select = implementRuntimeComponent({
               : null}
           </div>
         );
+      }}
+      getPopupContainer={node => {
+        return mountToBody ? document.body : node;
       }}
       mode={cProps.multiple ? 'multiple' : undefined}
       onClear={() => {

--- a/packages/arco-lib/src/components/Tree.tsx
+++ b/packages/arco-lib/src/components/Tree.tsx
@@ -16,13 +16,15 @@ const TreeStateSpec = Type.Object({
 function formatNode(
   nodeProps: NodeInstance['props']
 ): Static<typeof TreeNodeSpec> & { path: string[] } {
+  const { title, key, ...rest } = nodeProps.dataRef!;
   return {
-    title: nodeProps.title as string,
-    key: nodeProps._key!,
+    title: title as string,
+    key: key!,
     selectable: nodeProps.selectable,
     checkable: nodeProps.checkable,
     path: [...nodeProps.pathParentKeys!, nodeProps._key!],
     children: nodeProps.dataRef?.children || ([] as Static<typeof TreeNodeSpec>[]),
+    ...rest,
   };
 }
 

--- a/packages/arco-lib/src/generated/types/Link.ts
+++ b/packages/arco-lib/src/generated/types/Link.ts
@@ -3,10 +3,20 @@ import { StringUnion } from '../../sunmao-helper';
 import { Category } from '../../constants/category';
 
 export const LinkPropsSpec = {
+  asLink: Type.Boolean({
+    title: 'As Link',
+    category: Category.Basic,
+    description: 'If false, only the Link style is retained',
+  }),
   href: Type.String({
     title: 'Href',
     category: Category.Basic,
-    weight: 2,
+    conditions: [
+      {
+        key: 'asLink',
+        value: true,
+      },
+    ],
   }),
   content: Type.String({
     title: 'Content',
@@ -15,7 +25,13 @@ export const LinkPropsSpec = {
   }),
   openInNewPage: Type.Boolean({
     title: 'Open In New Page',
-    category: Category.Behavior,
+    category: Category.Basic,
+    conditions: [
+      {
+        key: 'asLink',
+        value: true,
+      },
+    ],
   }),
   hoverable: Type.Boolean({
     title: 'Hoverable',
@@ -28,6 +44,6 @@ export const LinkPropsSpec = {
   }),
   disabled: Type.Boolean({
     title: 'Disabled',
-    category: Category.Behavior,
+    category: Category.Basic,
   }),
 };

--- a/packages/arco-lib/src/generated/types/Select.ts
+++ b/packages/arco-lib/src/generated/types/Select.ts
@@ -45,6 +45,7 @@ export const SelectPropsSpec = {
     title: 'Label In Value',
     description:
       'Setting value format.The default is string, when set to true, the value format will turn to: { label: string, value: string }',
+    category: Category.Behavior,
   }),
   placeholder: Type.String({
     title: 'Placeholder',
@@ -98,6 +99,7 @@ export const SelectPropsSpec = {
     title: 'Show Option Title',
     description:
       'Whether to show the title on hover when the select option exceeds the width',
+    category: Category.Behavior,
   }),
   error: Type.Boolean({
     title: 'Error',
@@ -107,4 +109,33 @@ export const SelectPropsSpec = {
     title: 'Destroy On Hide',
     category: Category.Behavior,
   }),
+  mountToBody: Type.Boolean({
+    title: 'Mount To Body',
+    category: Category.Behavior,
+    description:
+      'The default is to mount the popup to the body, setting it to false will mount it to the current select element',
+  }),
+  autoFixPosition: Type.Boolean({
+    title: 'Auto Fix Position',
+    category: 'Popup Props',
+  }),
+  autoAlignPopupMinWidth: Type.Boolean({
+    title: 'Auto Align Popup Min Width',
+    category: 'Popup Props',
+  }),
+  autoAlignPopupWidth: Type.Boolean({
+    title: 'Auto Align Popup Width',
+    category: 'Popup Props',
+  }),
+  autoFitPosition: Type.Boolean({
+    title: 'Auto Fit Position',
+    category: 'Popup Props',
+  }),
+  position: StringUnion(
+    ['top', 'tl', 'tr', 'bottom', 'bl', 'br', 'left', 'lt', 'lb', 'right', 'rt', 'rb'],
+    {
+      title: 'Position',
+      category: 'Popup Props',
+    }
+  ),
 };

--- a/packages/arco-lib/src/generated/types/Tree.ts
+++ b/packages/arco-lib/src/generated/types/Tree.ts
@@ -19,6 +19,10 @@ export const TreePropsSpec = Type.Object({
       displayedKeys: ['title'],
     },
   }),
+  defaultExpandKeys: Type.Array(Type.String(), {
+    category: Category.Basic,
+    title: 'Expand Keys',
+  }),
   size: StringUnion(['mini', 'small', 'medium', 'large'], {
     category: Category.Style,
     title: 'Size',
@@ -29,6 +33,10 @@ export const TreePropsSpec = Type.Object({
   }),
   autoExpandParent: Type.Boolean({
     category: Category.Basic,
-    title: 'Auto Expand Node',
+    title: 'Auto Expand Parent',
+  }),
+  autoExpandParentWhenDataChanges: Type.Boolean({
+    category: Category.Basic,
+    title: 'Auto Expand Parent When Data Changes',
   }),
 });

--- a/packages/arco-lib/src/generated/types/Tree.ts
+++ b/packages/arco-lib/src/generated/types/Tree.ts
@@ -19,10 +19,6 @@ export const TreePropsSpec = Type.Object({
       displayedKeys: ['title'],
     },
   }),
-  defaultExpandKeys: Type.Array(Type.String(), {
-    category: Category.Basic,
-    title: 'Expand Keys',
-  }),
   size: StringUnion(['mini', 'small', 'medium', 'large'], {
     category: Category.Style,
     title: 'Size',
@@ -38,5 +34,21 @@ export const TreePropsSpec = Type.Object({
   autoExpandParentWhenDataChanges: Type.Boolean({
     category: Category.Basic,
     title: 'Auto Expand Parent When Data Changes',
+    conditions: [
+      {
+        key: 'autoExpandParent',
+        value: true,
+      },
+    ],
+  }),
+  defaultExpandKeys: Type.Array(Type.String(), {
+    category: Category.Basic,
+    title: 'Expand Keys',
+    conditions: [
+      {
+        key: 'autoExpandParent',
+        value: false,
+      },
+    ],
   }),
 });

--- a/packages/editor/src/services/EditorStore.ts
+++ b/packages/editor/src/services/EditorStore.ts
@@ -80,7 +80,6 @@ export class EditorStore {
       setComponents: action,
       setHoverComponentId: action,
       setDragOverComponentId: action,
-      setHoverComponentId: action,
     });
 
     this.eventBus.on('selectComponent', id => {


### PR DESCRIPTION
1.  feat(arco/Select): add trigger props to control the properties associated with the drop-down menu
2. feat(arco/Tree): add attributes to control the expansion of the tree 
3. feat(arco/Tree): selectedNode supports custom properties
4. feat(arco/Link): add onClick event and `asLink` properties are used to control whether or not to render as an `<a>` and add icon slot