### PR TITLE
perf(editor): improve ComponentForm performance

### DIFF
--- a/packages/editor/src/components/ComponentForm/ComponentForm.tsx
+++ b/packages/editor/src/components/ComponentForm/ComponentForm.tsx
@@ -90,7 +90,6 @@ export const ComponentForm: React.FC<Props> = observer(props => {
       node: (
         <VStack width="full" background="white">
           <SpecWidget
-            key={selectedComponent.id}
             component={selectedComponent}
             spec={cImpl.spec.properties}
             value={properties}
@@ -116,13 +115,7 @@ export const ComponentForm: React.FC<Props> = observer(props => {
     },
     {
       title: 'Styles',
-      node: (
-        <StyleTraitForm
-          key={selectedComponentId}
-          component={selectedComponent}
-          services={services}
-        />
-      ),
+      node: <StyleTraitForm component={selectedComponent} services={services} />,
     },
     {
       title: 'Traits',
@@ -144,7 +137,7 @@ export const ComponentForm: React.FC<Props> = observer(props => {
           <FormSection
             style={{ position: 'relative', zIndex: sections.length - i }}
             title={section.title}
-            key={`${section.title}-${selectedComponentId}`}
+            key={section.title}
           >
             {section.node}
           </FormSection>


### PR DESCRIPTION
Remove the keys of form. These keys are too high level, causing the whole form rerender.