### PR TITLE
feat(core): add deprecated metadata field

### DIFF
--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -6,6 +6,7 @@ export type Metadata<
   description?: string;
   annotations?: Record<string, any> & TAnnotations;
   exampleProperties?: TExample;
+  deprecated?: boolean;
 };
 
 type ComponentCategory =

--- a/packages/editor/src/components/ComponentForm/GeneralTraitFormList/AddTraitButton.tsx
+++ b/packages/editor/src/components/ComponentForm/GeneralTraitFormList/AddTraitButton.tsx
@@ -31,13 +31,18 @@ export const AddTraitButton: React.FC<Props> = props => {
       }, {} as Record<string, boolean>),
     [component]
   );
-  const traitTypes = useMemo(() => {
+  const traits = useMemo(() => {
     return registry
-      .getAllTraitTypes()
-      .filter(type => !hideCreateTraitsList.includes(type));
+      .getAllTraits()
+      .filter(
+        t =>
+          !t.metadata.deprecated &&
+          !hideCreateTraitsList.includes(`${t.version}/${t.metadata.name}`)
+      );
   }, [registry]);
 
-  const menuItems = traitTypes.map(type => {
+  const menuItems = traits.map(t => {
+    const type = `${t.version}/${t.metadata.name}`;
     return (
       <MenuItem
         key={type}

--- a/packages/editor/src/components/ComponentsList/ComponentList.tsx
+++ b/packages/editor/src/components/ComponentsList/ComponentList.tsx
@@ -12,7 +12,7 @@ import {
   InputRightElement,
   Tag,
 } from '@chakra-ui/react';
-import { CoreComponentName, CORE_VERSION } from '@sunmao-ui/shared';
+import { CoreComponentName } from '@sunmao-ui/shared';
 import { groupBy, sortBy } from 'lodash';
 import { EditorServices } from '../../types';
 import { ExplorerMenuTabs } from '../../constants/enum';
@@ -53,7 +53,7 @@ function getCategoryOrder(name: string): number {
 function getTagColor(version: string): string {
   if (version.startsWith('chakra_ui/')) {
     return 'teal';
-  } else if (version.startsWith(CORE_VERSION)) {
+  } else if (version.startsWith('core/')) {
     return 'yellow';
   } else {
     return 'blackAlpha';
@@ -86,6 +86,7 @@ export const ComponentList: React.FC<Props> = ({ services }) => {
       registry.getAllComponents().filter(c => {
         if (
           IGNORE_COMPONENTS.includes(c.metadata.name) ||
+          c.metadata.deprecated ||
           (checkedVersions.length && !checkedVersions.includes(c.version))
         ) {
           return false;

--- a/packages/runtime/src/components/core/Text.tsx
+++ b/packages/runtime/src/components/core/Text.tsx
@@ -27,6 +27,7 @@ export default implementRuntimeComponent({
     annotations: {
       category: 'Display',
     },
+    deprecated: true,
   },
   spec: {
     properties: PropsSpec,

--- a/packages/runtime/src/components/core/TextV2.tsx
+++ b/packages/runtime/src/components/core/TextV2.tsx
@@ -1,0 +1,46 @@
+import { Type } from '@sinclair/typebox';
+import {
+  CORE_VERSION_V2,
+  CoreComponentName,
+  PRESET_PROPERTY_CATEGORY,
+} from '@sunmao-ui/shared';
+import React from 'react';
+import { css } from '@emotion/css';
+import { implementRuntimeComponent } from '../../utils/buildKit';
+
+export default implementRuntimeComponent({
+  version: CORE_VERSION_V2,
+  metadata: {
+    name: CoreComponentName.Text,
+    displayName: 'Text',
+    description: 'Plain Text',
+    exampleProperties: { text: 'Hello, Sunmao!' },
+    annotations: {
+      category: 'Display',
+    },
+  },
+  spec: {
+    properties: Type.Object({
+      text: Type.String({
+        title: 'Text',
+        category: PRESET_PROPERTY_CATEGORY.Basic,
+      }),
+    }),
+    state: Type.Object({}),
+    methods: {},
+    slots: {},
+    styleSlots: ['content'],
+    events: [],
+  },
+})(({ text, customStyle, elementRef }) => {
+  return (
+    <span
+      className={css`
+        ${customStyle?.content}
+      `}
+      ref={elementRef}
+    >
+      {text}
+    </span>
+  );
+});

--- a/packages/runtime/src/services/Registry.tsx
+++ b/packages/runtime/src/services/Registry.tsx
@@ -3,6 +3,7 @@ import { parseType, SlotSpec } from '@sunmao-ui/core';
 // components
 /* --- core --- */
 import CoreText from '../components/core/Text';
+import CoreTextV2 from '../components/core/TextV2';
 import CoreRouter from '../components/core/Router';
 import CoreDummy from '../components/core/Dummy';
 import CoreModuleContainer from '../components/core/ModuleContainer';
@@ -247,6 +248,7 @@ export function initRegistry(
 ): Registry {
   const registry = new Registry(services, utilMethodManager);
   registry.registerComponent(CoreText);
+  registry.registerComponent(CoreTextV2);
   registry.registerComponent(CoreRouter);
   registry.registerComponent(CoreDummy);
   registry.registerComponent(CoreModuleContainer);

--- a/packages/shared/src/constants/core.ts
+++ b/packages/shared/src/constants/core.ts
@@ -1,4 +1,5 @@
 export const CORE_VERSION = 'core/v1';
+export const CORE_VERSION_V2 = 'core/v2';
 export declare const STYLE_VERSION = 'style/v1';
 // core components
 export enum CoreComponentName {


### PR DESCRIPTION
### Changes
1. Add a `deprecated` field in metadata. Deprecated components and traits are hidden in editor.
2. Add `core/v2/text` component. It property is more simple.