### PR TITLE
Revert "perf(editor): improve ComponentForm performance"

### DIFF
--- a/packages/editor/src/components/ComponentForm/ComponentForm.tsx
+++ b/packages/editor/src/components/ComponentForm/ComponentForm.tsx
@@ -90,6 +90,7 @@ export const ComponentForm: React.FC<Props> = observer(props => {
       node: (
         <VStack width="full" background="white">
           <SpecWidget
+            key={selectedComponent.id}
             component={selectedComponent}
             spec={cImpl.spec.properties}
             value={properties}
@@ -115,7 +116,13 @@ export const ComponentForm: React.FC<Props> = observer(props => {
     },
     {
       title: 'Styles',
-      node: <StyleTraitForm component={selectedComponent} services={services} />,
+      node: (
+        <StyleTraitForm
+          key={selectedComponentId}
+          component={selectedComponent}
+          services={services}
+        />
+      ),
     },
     {
       title: 'Traits',
@@ -137,7 +144,7 @@ export const ComponentForm: React.FC<Props> = observer(props => {
           <FormSection
             style={{ position: 'relative', zIndex: sections.length - i }}
             title={section.title}
-            key={section.title}
+            key={`${section.title}-${selectedComponentId}`}
           >
             {section.node}
           </FormSection>

--- a/packages/editor/tsup.config.ts
+++ b/packages/editor/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['cjs', 'esm', 'iife'],
+  format: ['cjs', 'esm'],
   legacyOutput: true,
   splitting: true,
   sourcemap: true,


### PR DESCRIPTION
We cannot add key to ComponentForm because it will cause bug when user switch between components. The old component's property could overwrite new component.

This reverts commit 46d587827eac6829de85c1539da0ce1930f22c55.