### PR TITLE
Lazy render properties field

### DIFF
--- a/packages/editor-sdk/src/components/Widgets/CategoryWidget.tsx
+++ b/packages/editor-sdk/src/components/Widgets/CategoryWidget.tsx
@@ -76,12 +76,12 @@ export const CategoryWidget: React.FC<WidgetProps<CategoryWidgetType>> = props =
   }, [spec.properties]);
 
   const onExpandedIndexChange = (index: ExpandedIndex) => {
-    console.log('index', index);
     setExpandedIndex(index as number[]);
   };
 
   return (
     <Accordion
+      reduceMotion
       width="full"
       index={expandedIndex}
       onChange={onExpandedIndexChange}

--- a/packages/editor-sdk/src/components/Widgets/CategoryWidget.tsx
+++ b/packages/editor-sdk/src/components/Widgets/CategoryWidget.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { ReactNode, useMemo, useState } from 'react';
 import { SpecWidget } from './SpecWidget';
 import { WidgetProps } from '../../types/widget';
 import { implementWidget } from '../../utils/widget';
@@ -10,6 +10,7 @@ import {
   AccordionIcon,
   Box,
   Accordion,
+  ExpandedIndex,
 } from '@chakra-ui/react';
 import {
   PRESET_PROPERTY_CATEGORY,
@@ -56,7 +57,7 @@ declare module '../../types/widget' {
 
 export const CategoryWidget: React.FC<WidgetProps<CategoryWidgetType>> = props => {
   const { component, spec, value, path, level, services, onChange } = props;
-
+  const [expandedIndex, setExpandedIndex] = useState([0]);
   const categories = useMemo<Category[]>(() => {
     const properties = (spec.properties || {}) as Property;
     Object.keys(properties).forEach(name => {
@@ -74,11 +75,50 @@ export const CategoryWidget: React.FC<WidgetProps<CategoryWidgetType>> = props =
     );
   }, [spec.properties]);
 
-  return (
-    <Accordion width="full" defaultIndex={[0]} allowMultiple>
-      {categories.map(category => {
-        const specs = category.specs;
+  const onExpandedIndexChange = (index: ExpandedIndex) => {
+    console.log('index', index);
+    setExpandedIndex(index as number[]);
+  };
 
+  return (
+    <Accordion
+      width="full"
+      index={expandedIndex}
+      onChange={onExpandedIndexChange}
+      allowMultiple
+    >
+      {categories.map((category, i) => {
+        const specs = category.specs;
+        let content: ReactNode | undefined;
+        if (expandedIndex.includes(i)) {
+          content = specs.map(propertySpec => {
+            const name = propertySpec.name;
+
+            if (typeof propertySpec === 'boolean') {
+              return null;
+            }
+            return shouldRender(propertySpec.conditions || [], value) ? (
+              <SpecWidget
+                key={name}
+                component={component}
+                spec={{
+                  ...propertySpec,
+                  title: propertySpec.title || name,
+                }}
+                value={value?.[name!]}
+                path={path.concat(name!)}
+                level={level + 1}
+                services={services}
+                onChange={newValue => {
+                  onChange({
+                    ...value,
+                    [name!]: newValue,
+                  });
+                }}
+              />
+            ) : null;
+          });
+        }
         return (
           <AccordionItem width="full" key={category.name}>
             <AccordionButton bg="white">
@@ -87,35 +127,7 @@ export const CategoryWidget: React.FC<WidgetProps<CategoryWidgetType>> = props =
               </Box>
               <AccordionIcon />
             </AccordionButton>
-            <AccordionPanel bg="white">
-              {specs.map(propertySpec => {
-                const name = propertySpec.name;
-
-                if (typeof propertySpec === 'boolean') {
-                  return null;
-                }
-                return shouldRender(propertySpec.conditions || [], value) ? (
-                  <SpecWidget
-                    key={name}
-                    component={component}
-                    spec={{
-                      ...propertySpec,
-                      title: propertySpec.title || name,
-                    }}
-                    value={value?.[name!]}
-                    path={path.concat(name!)}
-                    level={level + 1}
-                    services={services}
-                    onChange={newValue => {
-                      onChange({
-                        ...value,
-                        [name!]: newValue,
-                      });
-                    }}
-                  />
-                ) : null;
-              })}
-            </AccordionPanel>
+            <AccordionPanel bg="white">{content}</AccordionPanel>
           </AccordionItem>
         );
       })}

--- a/packages/editor/src/components/ComponentForm/ComponentForm.tsx
+++ b/packages/editor/src/components/ComponentForm/ComponentForm.tsx
@@ -133,6 +133,7 @@ export const ComponentForm: React.FC<Props> = observer(props => {
   return (
     <ErrorBoundary>
       <Accordion
+        reduceMotion
         className={ComponentFormStyle}
         defaultIndex={sections.map((_, i) => i)}
         background="gray.50"

--- a/packages/editor/src/components/ComponentForm/StyleTraitForm/StyleTraitForm.tsx
+++ b/packages/editor/src/components/ComponentForm/StyleTraitForm/StyleTraitForm.tsx
@@ -286,7 +286,7 @@ export const StyleTraitForm: React.FC<Props> = props => {
 
   return (
     <VStack width="full" alignItems="self-start" spacing="2">
-      <Accordion width="full" defaultIndex={[0]} allowMultiple>
+      <Accordion width="full" defaultIndex={[0]} allowMultiple reduceMotion>
         {styleForms}
       </Accordion>
       <Button

--- a/packages/editor/src/components/ComponentsList/ComponentList.tsx
+++ b/packages/editor/src/components/ComponentsList/ComponentList.tsx
@@ -121,7 +121,11 @@ export const ComponentList: React.FC<Props> = ({ services }) => {
           />
         </InputRightElement>
       </InputGroup>
-      <Accordion allowMultiple defaultIndex={categories.map((_, idx) => idx)}>
+      <Accordion
+        allowMultiple
+        defaultIndex={categories.map((_, idx) => idx)}
+        reduceMotion
+      >
         {categories.map(category => {
           return (
             <AccordionItem key={category.name}>

--- a/packages/editor/src/components/DataSource/DataSource.tsx
+++ b/packages/editor/src/components/DataSource/DataSource.tsx
@@ -29,7 +29,7 @@ const DATASOURCE_TYPES = Object.values(DataSourceType);
 export const DataSource: React.FC<Props> = props => {
   const { active, services } = props;
   const { editorStore } = services;
-  const NORMAL_DATASOURCES = DATA_DATASOURCES.map((item)=> ({
+  const NORMAL_DATASOURCES = DATA_DATASOURCES.map(item => ({
     ...item,
     title: item.type,
     datas: editorStore.dataSources[item.type],
@@ -89,6 +89,7 @@ export const DataSource: React.FC<Props> = props => {
         </Menu>
       </Flex>
       <Accordion
+        reduceMotion
         defaultIndex={[0].concat(NORMAL_DATASOURCES.map((_, i) => i + 1))}
         allowMultiple
       >


### PR DESCRIPTION
Chakra Accordion component does not support lazy mode so that the unexpanded categroy properties will stil be renderer.
I manually add lazy mode for it which can siginificantly improve the performance of components that have a lot of properties.

Also I close the animation of Accordion.

Before
![截屏2022-11-23 上午11 53 47](https://user-images.githubusercontent.com/12260952/203466262-f974ac68-9d75-4941-a5fa-ee79f6ecde25.png)

After
 
![截屏2022-11-23 上午11 44 45](https://user-images.githubusercontent.com/12260952/203466337-7fa74d87-fbf6-4165-94f6-a2a1e13984b5.png)
