### PR TITLE
add appentToBody & appentToParent option to PopoverWidget

### DIFF
--- a/packages/editor-sdk/src/components/Form/ArrayTable.tsx
+++ b/packages/editor-sdk/src/components/Form/ArrayTable.tsx
@@ -5,7 +5,7 @@ import { AddIcon } from '@chakra-ui/icons';
 import { generateDefaultValueFromSpec, isJSONSchema } from '@sunmao-ui/shared';
 import { JSONSchema7 } from 'json-schema';
 import { ArrayButtonGroup } from './ArrayButtonGroup';
-import { PopoverWidget } from '../Widgets/PopoverWidget';
+import { PopoverWidget, PopoverWidgetType } from '../Widgets/PopoverWidget';
 import { mergeWidgetOptionsIntoSpec } from '../../utils/widget';
 import { WidgetProps } from '../../types/widget';
 import { get } from 'lodash';
@@ -46,7 +46,11 @@ const DEFAULT_KEYS = ['index'];
 const TableRow: React.FC<RowProps> = props => {
   const { value, itemSpec, spec, level, path, children, itemValue, itemIndex, onChange } =
     props;
-  const { expressionOptions, displayedKeys = [] } = spec.widgetOptions || {};
+  const {
+    expressionOptions,
+    displayedKeys = [],
+    appendToBody,
+  } = spec.widgetOptions || {};
   const keys = displayedKeys.length ? displayedKeys : DEFAULT_KEYS;
   const mergedSpec = useMemo(
     () =>
@@ -57,9 +61,10 @@ const TableRow: React.FC<RowProps> = props => {
         },
         {
           expressionOptions,
+          appendToBody,
         }
       ),
-    [itemSpec, expressionOptions]
+    [itemSpec, expressionOptions, appendToBody]
   );
   const nextPath = useMemo(() => path.concat(String(itemIndex)), [path, itemIndex]);
   const onPopoverWidgetChange = useCallback(
@@ -77,7 +82,7 @@ const TableRow: React.FC<RowProps> = props => {
         <PopoverWidget
           {...props}
           value={itemValue}
-          spec={mergedSpec}
+          spec={mergedSpec as WidgetProps<PopoverWidgetType>}
           path={nextPath}
           level={level + 1}
           onChange={onPopoverWidgetChange}

--- a/packages/editor-sdk/src/components/Form/ArrayTable.tsx
+++ b/packages/editor-sdk/src/components/Form/ArrayTable.tsx
@@ -50,6 +50,7 @@ const TableRow: React.FC<RowProps> = props => {
     expressionOptions,
     displayedKeys = [],
     appendToBody,
+    appendToParent,
   } = spec.widgetOptions || {};
   const keys = displayedKeys.length ? displayedKeys : DEFAULT_KEYS;
   const mergedSpec = useMemo(
@@ -62,9 +63,10 @@ const TableRow: React.FC<RowProps> = props => {
         {
           expressionOptions,
           appendToBody,
+          appendToParent,
         }
       ),
-    [itemSpec, expressionOptions, appendToBody]
+    [itemSpec, expressionOptions, appendToBody, appendToParent]
   );
   const nextPath = useMemo(() => path.concat(String(itemIndex)), [path, itemIndex]);
   const onPopoverWidgetChange = useCallback(

--- a/packages/editor-sdk/src/components/Widgets/ArrayField.tsx
+++ b/packages/editor-sdk/src/components/Widgets/ArrayField.tsx
@@ -17,6 +17,7 @@ import { ArrayItemBox } from '../Form/ArrayItemBox';
 const ArrayFieldWidgetOptions = Type.Object({
   expressionOptions: Type.Optional(ExpressionWidgetOptionsSpec),
   displayedKeys: Type.Optional(Type.Array(Type.String())),
+  appendToBody: Type.Optional(Type.Boolean()),
 });
 
 type ArrayFieldWidgetType = `${typeof CORE_VERSION}/${CoreWidgetName.ArrayField}`;
@@ -101,5 +102,8 @@ export default implementWidget<ArrayFieldWidgetType>({
   version: CORE_VERSION,
   metadata: {
     name: CoreWidgetName.ArrayField,
+  },
+  spec: {
+    options: ArrayFieldWidgetOptions,
   },
 })(ArrayField);

--- a/packages/editor-sdk/src/components/Widgets/ArrayField.tsx
+++ b/packages/editor-sdk/src/components/Widgets/ArrayField.tsx
@@ -18,6 +18,7 @@ const ArrayFieldWidgetOptions = Type.Object({
   expressionOptions: Type.Optional(ExpressionWidgetOptionsSpec),
   displayedKeys: Type.Optional(Type.Array(Type.String())),
   appendToBody: Type.Optional(Type.Boolean()),
+  appendToParent: Type.Optional(Type.Boolean()),
 });
 
 type ArrayFieldWidgetType = `${typeof CORE_VERSION}/${CoreWidgetName.ArrayField}`;

--- a/packages/editor-sdk/src/components/Widgets/PopoverWidget.tsx
+++ b/packages/editor-sdk/src/components/Widgets/PopoverWidget.tsx
@@ -46,6 +46,7 @@ export type PopoverWidgetType = `${typeof CORE_VERSION}/${CoreWidgetName.Popover
 
 const PopoverWidgetOption = Type.Object({
   appendToBody: Type.Optional(Type.Boolean()),
+  appendToParent: Type.Optional(Type.Boolean()),
 });
 
 declare module '../../types/widget' {
@@ -204,9 +205,15 @@ export const PopoverWidget = React.forwardRef<
           />
         )}
       </PopoverTrigger>
-      <Portal containerRef={spec.widgetOptions?.appendToBody ? undefined : containerRef}>
-        {popoverContent}
-      </Portal>
+      {spec.widgetOptions?.appendToParent ? (
+        popoverContent
+      ) : (
+        <Portal
+          containerRef={spec.widgetOptions?.appendToBody ? undefined : containerRef}
+        >
+          {popoverContent}
+        </Portal>
+      )}
     </Popover>
   );
 });

--- a/packages/editor-sdk/src/components/Widgets/PopoverWidget.tsx
+++ b/packages/editor-sdk/src/components/Widgets/PopoverWidget.tsx
@@ -25,6 +25,7 @@ import {
   PREVENT_POPOVER_WIDGET_CLOSE_CLASS,
   ComponentFormElementId,
 } from '../../constants';
+import { Static, Type } from '@sinclair/typebox';
 
 type EvenType = {
   'sub-popover-close': string[];
@@ -41,11 +42,15 @@ type Children = {
   body?: React.ReactElement;
 };
 
-type PopoverWidgetType = `${typeof CORE_VERSION}/${CoreWidgetName.Popover}`;
+export type PopoverWidgetType = `${typeof CORE_VERSION}/${CoreWidgetName.Popover}`;
+
+const PopoverWidgetOption = Type.Object({
+  appendToBody: Type.Optional(Type.Boolean()),
+});
 
 declare module '../../types/widget' {
   interface WidgetOptionsMap {
-    'core/v1/popover': {};
+    'core/v1/popover': Static<typeof PopoverWidgetOption>;
   }
 }
 
@@ -56,7 +61,11 @@ export const PopoverWidget = React.forwardRef<
   React.ComponentPropsWithoutRef<React.ComponentType> & WidgetProps<PopoverWidgetType>
 >((props, ref) => {
   const { spec, path, children } = props;
-  const containerRef = useRef(document.getElementById(ComponentFormElementId) || null);
+  const containerRef = useRef(
+    spec.widgetOptions?.appendToBody
+      ? null
+      : document.getElementById(ComponentFormElementId)
+  );
   const isObjectChildren = children && typeof children === 'object';
   const [isInit, setIsInit] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
@@ -155,6 +164,25 @@ export const PopoverWidget = React.forwardRef<
     },
   }));
 
+  const popoverContent = (
+    <PopoverContent
+      width="sm"
+      className={PREVENT_POPOVER_WIDGET_CLOSE_CLASS}
+      onClick={handleClickContent}
+    >
+      <PopoverArrow />
+      <PopoverBody maxHeight="75vh" overflow="auto">
+        {isInit ? (
+          isObjectChildren && 'body' in children ? (
+            (children as Children).body
+          ) : (
+            <SpecWidget {...props} spec={mergedSpec} />
+          )
+        ) : null}
+      </PopoverBody>
+    </PopoverContent>
+  );
+
   return (
     <Popover
       isLazy
@@ -176,23 +204,8 @@ export const PopoverWidget = React.forwardRef<
           />
         )}
       </PopoverTrigger>
-      <Portal containerRef={containerRef}>
-        <PopoverContent
-          width="sm"
-          className={PREVENT_POPOVER_WIDGET_CLOSE_CLASS}
-          onClick={handleClickContent}
-        >
-          <PopoverArrow />
-          <PopoverBody maxHeight="75vh" overflow="auto">
-            {isInit ? (
-              isObjectChildren && 'body' in children ? (
-                (children as Children).body
-              ) : (
-                <SpecWidget {...props} spec={mergedSpec} />
-              )
-            ) : null}
-          </PopoverBody>
-        </PopoverContent>
+      <Portal containerRef={spec.widgetOptions?.appendToBody ? undefined : containerRef}>
+        {popoverContent}
       </Portal>
     </Popover>
   );
@@ -202,5 +215,8 @@ export default implementWidget<PopoverWidgetType>({
   version: CORE_VERSION,
   metadata: {
     name: CoreWidgetName.Popover,
+  },
+  spec: {
+    options: PopoverWidgetOption,
   },
 })(PopoverWidget);

--- a/packages/editor-sdk/src/components/Widgets/PopoverWidget.tsx
+++ b/packages/editor-sdk/src/components/Widgets/PopoverWidget.tsx
@@ -171,7 +171,7 @@ export const PopoverWidget = React.forwardRef<
       onClick={handleClickContent}
     >
       <PopoverArrow />
-      <PopoverBody maxHeight="75vh" overflow="auto">
+      <PopoverBody maxHeight="75vh" overflow="auto" paddingBottom="96px">
         {isInit ? (
           isObjectChildren && 'body' in children ? (
             (children as Children).body

--- a/packages/editor-sdk/src/components/Widgets/StyleWidgets/ColorWidget.tsx
+++ b/packages/editor-sdk/src/components/Widgets/StyleWidgets/ColorWidget.tsx
@@ -19,12 +19,13 @@ import { Static, Type } from '@sinclair/typebox';
 
 type ColorWidgetType = `${typeof CORE_VERSION}/${StyleWidgetName.Color}`;
 
-const PopoverWidgetOption = Type.Object({
+const ColorWidgetOption = Type.Object({
   appendToBody: Type.Optional(Type.Boolean()),
+  appendToParent: Type.Optional(Type.Boolean()),
 });
 declare module '../../../types/widget' {
   interface WidgetOptionsMap {
-    'core/v1/color': Static<typeof PopoverWidgetOption>;
+    'core/v1/color': Static<typeof ColorWidgetOption>;
   }
 }
 
@@ -87,11 +88,15 @@ export const ColorWidget: React.FC<WidgetProps<ColorWidgetType, string>> = props
               boxShadow="rgba(149, 157, 165, 0.2) 0px 8px 24px"
             />
           </PopoverTrigger>
-          <Portal
-            containerRef={spec.widgetOptions?.appendToBody ? undefined : containerRef}
-          >
-            {popoverContent}
-          </Portal>
+          {spec.widgetOptions?.appendToParent ? (
+            popoverContent
+          ) : (
+            <Portal
+              containerRef={spec.widgetOptions?.appendToBody ? undefined : containerRef}
+            >
+              {popoverContent}
+            </Portal>
+          )}
         </Popover>
       </InputRightElement>
     </InputGroup>
@@ -104,6 +109,6 @@ export default implementWidget<ColorWidgetType>({
     name: StyleWidgetName.Color,
   },
   spec: {
-    options: PopoverWidgetOption,
+    options: ColorWidgetOption,
   },
 })(ColorWidget);

--- a/packages/editor-sdk/src/components/Widgets/StyleWidgets/ColorWidget.tsx
+++ b/packages/editor-sdk/src/components/Widgets/StyleWidgets/ColorWidget.tsx
@@ -15,12 +15,16 @@ import {
   Portal,
 } from '@chakra-ui/react';
 import { ComponentFormElementId } from '../../../constants';
+import { Static, Type } from '@sinclair/typebox';
 
 type ColorWidgetType = `${typeof CORE_VERSION}/${StyleWidgetName.Color}`;
 
+const PopoverWidgetOption = Type.Object({
+  appendToBody: Type.Optional(Type.Boolean()),
+});
 declare module '../../../types/widget' {
   interface WidgetOptionsMap {
-    'core/v1/color': {};
+    'core/v1/color': Static<typeof PopoverWidgetOption>;
   }
 }
 
@@ -32,14 +36,33 @@ const SketchPicker = React.lazy(async () => {
 });
 
 export const ColorWidget: React.FC<WidgetProps<ColorWidgetType, string>> = props => {
-  const { value, onChange } = props;
-  const containerRef = useRef(document.getElementById(ComponentFormElementId) || null);
+  const { value, onChange, spec } = props;
+  const containerRef = useRef(
+    spec.widgetOptions?.appendToBody
+      ? null
+      : document.getElementById(ComponentFormElementId)
+  );
   const onColorChange = ({ rgb }: any) => {
     onChange(`rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${rgb.a})`);
   };
   const onInputChange = (value: string) => {
     onChange(value);
   };
+
+  const popoverContent = (
+    <PopoverContent w="auto">
+      <PopoverArrow />
+      <PopoverBody padding={0}>
+        <Suspense fallback={'Loading Color Picker'}>
+          <SketchPicker
+            width="250px"
+            color={value || '#fff'}
+            onChangeComplete={onColorChange}
+          />
+        </Suspense>
+      </PopoverBody>
+    </PopoverContent>
+  );
 
   return (
     <InputGroup>
@@ -64,19 +87,10 @@ export const ColorWidget: React.FC<WidgetProps<ColorWidgetType, string>> = props
               boxShadow="rgba(149, 157, 165, 0.2) 0px 8px 24px"
             />
           </PopoverTrigger>
-          <Portal containerRef={containerRef}>
-            <PopoverContent w="auto">
-              <PopoverArrow />
-              <PopoverBody padding={0}>
-                <Suspense fallback={'Loading Color Picker'}>
-                  <SketchPicker
-                    width="250px"
-                    color={value || '#fff'}
-                    onChangeComplete={onColorChange}
-                  />
-                </Suspense>
-              </PopoverBody>
-            </PopoverContent>
+          <Portal
+            containerRef={spec.widgetOptions?.appendToBody ? undefined : containerRef}
+          >
+            {popoverContent}
           </Portal>
         </Popover>
       </InputRightElement>
@@ -88,5 +102,8 @@ export default implementWidget<ColorWidgetType>({
   version: CORE_VERSION,
   metadata: {
     name: StyleWidgetName.Color,
+  },
+  spec: {
+    options: PopoverWidgetOption,
   },
 })(ColorWidget);

--- a/packages/editor/src/components/DataSource/ApiForm/Basic.tsx
+++ b/packages/editor/src/components/DataSource/ApiForm/Basic.tsx
@@ -84,6 +84,7 @@ export const Basic: React.FC<Props> = props => {
             FetchTraitPropertiesSpec.properties.onComplete as JSONSchema7,
             {
               displayedKeys: ['componentId', 'method.name', 'method.parameters'],
+              appendToParent: true,
             }
           )}
           level={1}
@@ -101,6 +102,7 @@ export const Basic: React.FC<Props> = props => {
             FetchTraitPropertiesSpec.properties.onError as JSONSchema7,
             {
               displayedKeys: ['componentId', 'method.name', 'method.parameters'],
+              appendToParent: true,
             }
           )}
           level={1}


### PR DESCRIPTION
By default, PopoverWidget will append to `ComponentForm`.
Sometimes, it still need to be appended to body in some custom widget. So we offer `appentToBody` & `appentToParent` for developer to control it.