### PR TITLE
add versions to localStorage trait

### DIFF
--- a/packages/editor/__tests__/validator/mock.ts
+++ b/packages/editor/__tests__/validator/mock.ts
@@ -365,6 +365,7 @@ export const DynamicStateTraitSchema: ComponentSchema[] = [
         properties: {
           key: 'value',
           initialValue: {},
+          version: 0,
         },
       },
     ],


### PR DESCRIPTION
Add a `versions` field to localStorage, stored in the meta. The behavior of localStorage is now
- If the key already exists and the version is less than the existing version, then the existing localStorage value is read and synchronised to the global state.
- If the key already exists and the version is greater than the existing version, then the current localStorage is stored/updated using the given initial value and key
- For a previous value such as `#localStorage0@value:4000` it will become `#localStorage0@value:{"value":4000, "meta":{"version":0}}`.
