### PR TITLE
feat: support default value for property spec

### DIFF
--- a/packages/editor-sdk/src/components/Widgets/StringField.tsx
+++ b/packages/editor-sdk/src/components/Widgets/StringField.tsx
@@ -23,7 +23,11 @@ const EnumField: React.FC<WidgetProps> = props => {
   const options = (spec.enum || []).map(item => item?.toString() || '');
 
   return (
-    <Select value={value} onChange={evt => onChange(evt.currentTarget.value)}>
+    <Select
+      value={value}
+      onChange={evt => onChange(evt.currentTarget.value)}
+      placeholder="Select option"
+    >
       {options.map((value, idx) => {
         return <option key={idx}>{value}</option>;
       })}

--- a/packages/editor/src/components/ComponentForm/ComponentForm.tsx
+++ b/packages/editor/src/components/ComponentForm/ComponentForm.tsx
@@ -3,7 +3,6 @@ import { observer } from 'mobx-react-lite';
 import { Accordion, Input, Text, VStack } from '@chakra-ui/react';
 import { ComponentFormElementId, SpecWidget } from '@sunmao-ui/editor-sdk';
 import { parseType } from '@sunmao-ui/core';
-import { generateDefaultValueFromSpec } from '@sunmao-ui/shared';
 import { css } from '@emotion/css';
 
 import { EventTraitForm } from './EventTraitForm';
@@ -47,10 +46,7 @@ export const ComponentForm: React.FC<Props> = observer(props => {
   }
   const { version, name } = parseType(selectedComponent.type);
   const cImpl = registry.getComponent(version, name);
-  const properties = Object.assign(
-    generateDefaultValueFromSpec(cImpl.spec.properties)!,
-    selectedComponent.properties
-  );
+  const properties = selectedComponent.properties;
 
   const changeComponentId = (selectedComponentId: string, value: string) => {
     eventBus.send(

--- a/packages/editor/src/components/ComponentForm/GeneralTraitFormList/GeneralTraitForm.tsx
+++ b/packages/editor/src/components/ComponentForm/GeneralTraitFormList/GeneralTraitForm.tsx
@@ -3,7 +3,6 @@ import { ComponentSchema, TraitSchema } from '@sunmao-ui/core';
 import { HStack, IconButton, VStack } from '@chakra-ui/react';
 import { CloseIcon } from '@chakra-ui/icons';
 import { SpecWidget } from '@sunmao-ui/editor-sdk';
-import { generateDefaultValueFromSpec } from '@sunmao-ui/shared';
 import { formWrapperCSS } from '../style';
 import { EditorServices } from '../../../types';
 import { genOperation } from '../../../operations';
@@ -21,10 +20,7 @@ export const GeneralTraitForm: React.FC<Props> = props => {
   const { registry, eventBus } = services;
 
   const tImpl = registry.getTraitByType(trait.type);
-  const properties = Object.assign(
-    generateDefaultValueFromSpec(tImpl.spec.properties)!,
-    trait.properties
-  );
+  const properties = trait.properties;
   const onChange = (newValue: any) => {
     const operation = genOperation(registry, 'modifyTraitProperty', {
       componentId: component.id,

--- a/packages/editor/src/components/ComponentForm/GeneralTraitFormList/GeneralTraitFormList.tsx
+++ b/packages/editor/src/components/ComponentForm/GeneralTraitFormList/GeneralTraitFormList.tsx
@@ -20,10 +20,11 @@ export const GeneralTraitFormList: React.FC<Props> = props => {
   const { eventBus, registry } = services;
 
   const onAddTrait = (type: string) => {
-    const traitSpec = registry.getTraitByType(type).spec;
-    const initProperties = generateDefaultValueFromSpec(
-      traitSpec.properties
-    ) as JSONSchema7Object;
+    const traitDefine = registry.getTraitByType(type);
+    const traitSpec = traitDefine.spec;
+    const initProperties =
+      traitDefine.metadata.exampleProperties ||
+      (generateDefaultValueFromSpec(traitSpec.properties) as JSONSchema7Object);
     eventBus.send(
       'operation',
       genOperation(registry, 'createTrait', {

--- a/packages/editor/src/components/DataSource/DataSourceList.tsx
+++ b/packages/editor/src/components/DataSource/DataSourceList.tsx
@@ -99,10 +99,13 @@ export const DataSourceList: React.FC<Props> = props => {
   );
   const onCreateDSFromTrait = useCallback(
     (type: string) => {
-      const propertiesSpec = registry.getTraitByType(type).spec.properties;
-      const defaultProperties = generateDefaultValueFromSpec(propertiesSpec, {
-        genArrayItemDefaults: false,
-      });
+      const traitDefine = registry.getTraitByType(type);
+      const propertiesSpec = traitDefine.spec.properties;
+      const defaultProperties =
+        traitDefine.metadata.exampleProperties ||
+        generateDefaultValueFromSpec(propertiesSpec, {
+          genArrayItemDefaults: false,
+        });
       const name = type.split('/')[2];
       const id = getNewId(name);
 

--- a/packages/editor/src/operations/branch/datasource/createDataSourceBranchOperation.ts
+++ b/packages/editor/src/operations/branch/datasource/createDataSourceBranchOperation.ts
@@ -18,10 +18,13 @@ export type CreateDataSourceBranchOperationContext = {
 export class CreateDataSourceBranchOperation extends BaseBranchOperation<CreateDataSourceBranchOperationContext> {
   do(prev: AppModel): AppModel {
     const { id, type, defaultProperties } = this.context;
-    const traitSpec = this.registry.getTraitByType(type).spec;
-    const initProperties = generateDefaultValueFromSpec(traitSpec.properties, {
-      genArrayItemDefaults: true,
-    }) as JSONSchema7Object;
+    const traitDefine = this.registry.getTraitByType(type);
+    const traitSpec = traitDefine.spec;
+    const initProperties =
+      traitDefine.metadata.exampleProperties ||
+      (generateDefaultValueFromSpec(traitSpec.properties, {
+        genArrayItemDefaults: true,
+      }) as JSONSchema7Object);
 
     this.operationStack.insert(
       new CreateComponentBranchOperation(this.registry, {

--- a/packages/runtime/src/traits/core/ArrayState.tsx
+++ b/packages/runtime/src/traits/core/ArrayState.tsx
@@ -5,7 +5,7 @@ import { CORE_VERSION, CoreTraitName } from '@sunmao-ui/shared';
 type KeyValue = { key: string; value: unknown };
 
 export const ArrayStateTraitPropertiesSpec = Type.Object({
-  key: Type.String(),
+  key: Type.String({ default: 'value' }),
   initialValue: Type.Optional(Type.Array(Type.Any())),
 });
 

--- a/packages/runtime/src/traits/core/LocalStorage.tsx
+++ b/packages/runtime/src/traits/core/LocalStorage.tsx
@@ -65,6 +65,7 @@ function getLocalStorage(
 export const LocalStorageTraitPropertiesSpec = Type.Object({
   key: Type.String({
     title: 'Key',
+    default: 'value',
   }),
   initialValue: Type.Any({
     title: 'Initial Value',

--- a/packages/runtime/src/traits/core/State.tsx
+++ b/packages/runtime/src/traits/core/State.tsx
@@ -7,6 +7,7 @@ type KeyValue = { key: string; value: unknown };
 export const StateTraitPropertiesSpec = Type.Object({
   key: Type.String({
     title: 'Key',
+    default: 'value',
   }),
   initialValue: Type.Any({
     title: 'Initial Value',


### PR DESCRIPTION
## Default Value
The `generateDefaultValueFromSpec` would use the `spec.default` to generate the properties default values.

## Init The Trait Properties
The properties values of the trait is now initialized preferentially using `exampleProperties`.

## The Component And Trait Form
The components and traits form no longer use `generateDefaultValueFromSpec` to generate properties values, because it can cause the editor shows value and actual value is different. For example, an enumeration type property whose value is `undefined` will appear as if the first option has been selected if the default value is generated in the form, which will mislead the user.