### PR TITLE
Editor support emit and listen module's event

### DIFF
--- a/packages/editor-sdk/src/types/editor.ts
+++ b/packages/editor-sdk/src/types/editor.ts
@@ -7,6 +7,11 @@ export interface EditorServicesInterface extends UIServices {
   registry: RegistryInterface;
   editorStore: {
     components: ComponentSchema[];
+    currentEditingTarget: {
+      kind: 'app' | 'module';
+      version: string;
+      name: string;
+    };
   };
   appModelManager: {
     appModel: any;

--- a/packages/runtime/src/services/StateManager.ts
+++ b/packages/runtime/src/services/StateManager.ts
@@ -18,7 +18,7 @@ dayjs.locale('zh-cn');
 type EvalOptions = {
   scopeObject?: Record<string, any>;
   overrideScope?: boolean;
-  fallbackWhenError?: (exp: string) => any;
+  fallbackWhenError?: (exp: string, err: Error) => any;
   // when ignoreEvalError is true, the eval process will continue after error happens in nests expression.
   ignoreEvalError?: boolean;
   slotKey?: string;
@@ -128,7 +128,9 @@ export class StateManager {
           consoleError(ConsoleType.Expression, raw, expressionError.message);
         }
 
-        return fallbackWhenError ? fallbackWhenError(raw) : expressionError;
+        return fallbackWhenError
+          ? fallbackWhenError(raw, expressionError)
+          : expressionError;
       }
       return undefined;
     }

--- a/packages/runtime/src/utils/runEventHandler.ts
+++ b/packages/runtime/src/utils/runEventHandler.ts
@@ -1,6 +1,6 @@
 import { Static, Type } from '@sinclair/typebox';
 import { debounce, throttle, delay } from 'lodash';
-import { EventCallBackHandlerSpec } from '@sunmao-ui/shared';
+import { EventCallBackHandlerSpec, MODULE_ID_EXP } from '@sunmao-ui/shared';
 import { type PropsBeforeEvaled } from '@sunmao-ui/core';
 import { UIServices } from '../types';
 
@@ -18,6 +18,10 @@ export const runEventHandler = (
     // Eval before sending event to assure the handler object is evaled from the latest state.
     const evalOptions = {
       slotKey,
+      // keep MODULE_ID_EXP when error
+      fallbackWhenError(exp: string, err: Error) {
+        return exp === MODULE_ID_EXP ? exp : err;
+      },
     };
     const evaledHandlers = stateManager.deepEval(rawHandlers, evalOptions) as Static<
       typeof EventCallBackHandlerSpec

--- a/packages/shared/src/constants/expression.ts
+++ b/packages/shared/src/constants/expression.ts
@@ -7,6 +7,7 @@ export const LIST_ITEM_INDEX_EXP = '$i';
 export const SLOT_PROPS_EXP = '$slot';
 export const GLOBAL_UTIL_METHOD_ID = '$utils';
 export const GLOBAL_MODULE_ID = '$module';
+export const MODULE_ID_EXP = '{{$moduleId}}';
 
 export const ExpressionKeywords = [
   LIST_ITEM_EXP,

--- a/packages/shared/src/specs/module.ts
+++ b/packages/shared/src/specs/module.ts
@@ -1,6 +1,7 @@
 import { EventHandlerSpec } from './event';
 import { Type } from '@sinclair/typebox';
 import { CORE_VERSION, CoreWidgetName } from '../constants/core';
+import { MODULE_ID_EXP } from '../constants';
 
 export const ModuleRenderSpec = Type.Object(
   {
@@ -27,3 +28,7 @@ export const ModuleRenderSpec = Type.Object(
     widget: 'core/v1/module',
   }
 );
+
+export const ModuleEventMethodSpec = Type.Object({
+  moduleId: Type.Literal(MODULE_ID_EXP),
+});


### PR DESCRIPTION
1. Allow user choose `$module` as event target. This is the way to emit event in module to outside.
![截屏2023-01-10 下午1 33 52](https://user-images.githubusercontent.com/12260952/211473680-2c017499-3f4f-4aa1-a4bf-b7bff2300670.png)
2. Allow user listen events in module's spec in the `ModuleContainer`'s `eventHandlers`
![截屏2023-01-10 下午1 59 20](https://user-images.githubusercontent.com/12260952/211473074-e24b9162-1832-47ed-a177-16ff34102b0d.png)
