### PR TITLE
refactoring module forms

### DIFF
--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -15,9 +15,7 @@ export type Module = {
 
 type ModuleSpec = {
   properties: JSONSchema7;
-  events: {
-    name: string;
-  }[];
+  events: string[];
   stateMap: Record<string, string>;
 };
 
@@ -45,12 +43,6 @@ export function createModule(options: CreateModuleOptions): RuntimeModule {
       exampleProperties: options.metadata.exampleProperties || {},
     },
     spec: {
-      // `json-schema-editor` has a readonly root object by default,
-      // it provides two schema formats,array({type:'array'}) and object({type:'object'}).
-      // In sunmao, we only use the object schema, so we need to specify a default value here
-      // and silently fail when root selects array.
-      // This is a bit obscure, so should remove the array type of root from the json-schema-editor later
-      // TODO remove the array type of root from the json-schema-editor
       properties: { type: 'object' },
       events: [],
       stateMap: {},

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -15,7 +15,9 @@ export type Module = {
 
 type ModuleSpec = {
   properties: JSONSchema7;
-  events: string[];
+  events: {
+    name: string;
+  }[];
   stateMap: Record<string, string>;
 };
 

--- a/packages/editor-sdk/src/components/Widgets/ModuleWidget.tsx
+++ b/packages/editor-sdk/src/components/Widgets/ModuleWidget.tsx
@@ -4,7 +4,12 @@ import { WidgetProps } from '../../types/widget';
 import { implementWidget } from '../../utils/widget';
 import { SpecWidget } from './SpecWidget';
 import { CORE_VERSION, CoreWidgetName, isJSONSchema } from '@sunmao-ui/shared';
+import { isExpression } from '../../utils/validator';
 import { css } from '@emotion/css';
+import { mapValues } from 'lodash';
+import { Type, TSchema } from '@sinclair/typebox';
+import type { JSONSchema7 } from 'json-schema';
+import { getType, Types } from './ExpressionWidget';
 
 const LabelStyle = css`
   font-weight: normal;
@@ -18,6 +23,35 @@ declare module '../../types/widget' {
     'core/v1/module': {};
   }
 }
+
+const genSpec = (type: Types, target: any): TSchema => {
+  switch (type) {
+    case Types.ARRAY: {
+      const arrayType = getType(target[0]);
+      console.log('array', target, genSpec(arrayType, target[0]));
+      return Type.Array(genSpec(arrayType, target[0]));
+    }
+    case Types.OBJECT: {
+      const objType: Record<string, any> = {};
+      Object.keys(target).forEach(k => {
+        const type = getType(target[k]);
+        objType[k] = genSpec(type, target[k]);
+      });
+      return Type.Object(objType);
+    }
+    case Types.STRING:
+      return Type.String();
+    case Types.NUMBER:
+      return Type.Number();
+    case Types.BOOLEAN:
+      return Type.Boolean();
+    case Types.NULL:
+    case Types.UNDEFINED:
+      return Type.Any();
+    default:
+      return Type.Any();
+  }
+};
 
 export const ModuleWidget: React.FC<WidgetProps<ModuleWidgetType>> = props => {
   const { component, value, spec, services, path, level, onChange } = props;
@@ -65,6 +99,21 @@ export const ModuleWidget: React.FC<WidgetProps<ModuleWidgetType>> = props => {
     });
   };
 
+  const modulePropertiesSpec = useMemo<JSONSchema7>(() => {
+    const obj = mapValues(module?.metadata.exampleProperties, p => {
+      let type = Types.STRING;
+      let result;
+      if (isExpression(p)) {
+        result = services.stateManager.deepEval(p);
+        type = getType(result);
+      }
+      const spec = genSpec(type, result);
+      return spec;
+    });
+
+    return Type.Object(obj);
+  }, [module?.metadata.exampleProperties, services.stateManager]);
+
   return (
     <Box p="2" border="1px solid" borderColor="gray.200" borderRadius="4">
       <SpecWidget
@@ -99,7 +148,7 @@ export const ModuleWidget: React.FC<WidgetProps<ModuleWidgetType>> = props => {
         <SpecWidget
           component={component}
           spec={{
-            ...module.spec.properties,
+            ...modulePropertiesSpec,
             title: 'Module Properties',
           }}
           path={[]}

--- a/packages/editor-sdk/src/components/Widgets/ModuleWidget.tsx
+++ b/packages/editor-sdk/src/components/Widgets/ModuleWidget.tsx
@@ -4,7 +4,6 @@ import { WidgetProps } from '../../types/widget';
 import { implementWidget } from '../../utils/widget';
 import { SpecWidget } from './SpecWidget';
 import { CORE_VERSION, CoreWidgetName, isJSONSchema } from '@sunmao-ui/shared';
-import { isExpression } from '../../utils/validator';
 import { css } from '@emotion/css';
 import { mapValues } from 'lodash';
 import { Type, TSchema } from '@sinclair/typebox';
@@ -28,7 +27,6 @@ const genSpec = (type: Types, target: any): TSchema => {
   switch (type) {
     case Types.ARRAY: {
       const arrayType = getType(target[0]);
-      console.log('array', target, genSpec(arrayType, target[0]));
       return Type.Array(genSpec(arrayType, target[0]));
     }
     case Types.OBJECT: {
@@ -101,13 +99,10 @@ export const ModuleWidget: React.FC<WidgetProps<ModuleWidgetType>> = props => {
 
   const modulePropertiesSpec = useMemo<JSONSchema7>(() => {
     const obj = mapValues(module?.metadata.exampleProperties, p => {
-      let type = Types.STRING;
-      let result;
-      if (isExpression(p)) {
-        result = services.stateManager.deepEval(p);
-        type = getType(result);
-      }
+      const result = services.stateManager.deepEval(p);
+      const type = getType(result);
       const spec = genSpec(type, result);
+
       return spec;
     });
 

--- a/packages/editor/src/components/Explorer/Explorer.tsx
+++ b/packages/editor/src/components/Explorer/Explorer.tsx
@@ -3,7 +3,15 @@ import ErrorBoundary from '../ErrorBoundary';
 import { ExplorerForm } from './ExplorerForm/ExplorerForm';
 import { ExplorerTree } from './ExplorerTree';
 import { EditorServices } from '../../types';
-import { Box } from '@chakra-ui/react';
+import {
+  Box,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+} from '@chakra-ui/react';
 
 type Props = {
   services: EditorServices;
@@ -20,30 +28,40 @@ export const Explorer: React.FC<Props> = ({ services }) => {
     setCurrentName(name);
     setIsEditingMode(true);
   };
-  const onBack = () => {
-    setIsEditingMode(false);
-  };
-  if (isEditingMode) {
-    return (
-      <ErrorBoundary>
-        <Box padding={4}>
-          <ExplorerForm
-            formType={formType}
-            version={currentVersion}
-            name={currentName}
-            setCurrentVersion={setCurrentVersion}
-            setCurrentName={setCurrentName}
-            onBack={onBack}
-            services={services}
-          />
-        </Box>
-      </ErrorBoundary>
-    );
-  }
+
   return (
     <ErrorBoundary>
       <Box padding={4}>
         <ExplorerTree onEdit={onEdit} services={services} />
+        <Modal
+          onClose={() => {
+            setIsEditingMode(false);
+          }}
+          closeOnOverlayClick
+          isOpen={isEditingMode}
+        >
+          <ModalOverlay />
+          <ModalContent p="10px" maxW="800px">
+            <ModalCloseButton />
+            <ModalHeader> {formType === 'app' ? 'Application' : 'Module'}</ModalHeader>
+            <ModalBody
+              w="full"
+              flex="1 1 auto"
+              height="75vh"
+              alignItems="start"
+              overflow="auto"
+            >
+              <ExplorerForm
+                formType={formType}
+                version={currentVersion}
+                name={currentName}
+                setCurrentVersion={setCurrentVersion}
+                setCurrentName={setCurrentName}
+                services={services}
+              />
+            </ModalBody>
+          </ModalContent>
+        </Modal>
       </Box>
     </ErrorBoundary>
   );

--- a/packages/editor/src/components/Explorer/ExplorerForm/AppMetaDataForm.tsx
+++ b/packages/editor/src/components/Explorer/ExplorerForm/AppMetaDataForm.tsx
@@ -54,7 +54,9 @@ export const AppMetaDataForm: React.FC<AppMetaDataFormProps> = observer(
                   }}
                 />
                 {isAppVersionError && (
-                  <FormErrorMessage>Application name can not be empty</FormErrorMessage>
+                  <FormErrorMessage>
+                    Application version can not be empty
+                  </FormErrorMessage>
                 )}
               </VStack>
             </HStack>

--- a/packages/editor/src/components/Explorer/ExplorerForm/AppMetaDataForm.tsx
+++ b/packages/editor/src/components/Explorer/ExplorerForm/AppMetaDataForm.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { FormControl, FormLabel, Input, VStack } from '@chakra-ui/react';
+import {
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  HStack,
+  Input,
+  VStack,
+} from '@chakra-ui/react';
 import { useFormik } from 'formik';
 import { observer } from 'mobx-react-lite';
 import { EditorServices } from '../../../types';
@@ -26,26 +33,53 @@ export const AppMetaDataForm: React.FC<AppMetaDataFormProps> = observer(
       initialValues: data,
       onSubmit,
     });
+
+    const isAppVersionError = formik.values.version === '';
+    const isAppNameError = formik.values.name === '';
     return (
-      <VStack>
-        <FormControl isRequired>
-          <FormLabel>App Version</FormLabel>
-          <Input
-            name="version"
-            value={formik.values.version}
-            onChange={formik.handleChange}
-            onBlur={() => formik.submitForm()}
-          />
-        </FormControl>
-        <FormControl isRequired>
-          <FormLabel>App Name</FormLabel>
-          <Input
-            name="name"
-            value={formik.values.name}
-            onChange={formik.handleChange}
-            onBlur={() => formik.submitForm()}
-          />
-        </FormControl>
+      <VStack w="full" spacing="5">
+        <HStack w="full" align="normal">
+          <FormControl isInvalid={isAppVersionError}>
+            <HStack align="normal">
+              <FormLabel>Version</FormLabel>
+              <VStack w="full" align="normal">
+                <Input
+                  name="version"
+                  value={formik.values.version}
+                  onChange={formik.handleChange}
+                  onBlur={() => {
+                    if (formik.values.version && formik.values.name) {
+                      formik.submitForm();
+                    }
+                  }}
+                />
+                {isAppVersionError && (
+                  <FormErrorMessage>Application name can not be empty</FormErrorMessage>
+                )}
+              </VStack>
+            </HStack>
+          </FormControl>
+          <FormControl isInvalid={isAppNameError}>
+            <HStack align="normal">
+              <FormLabel>Name</FormLabel>
+              <VStack w="full" align="normal">
+                <Input
+                  name="name"
+                  value={formik.values.name}
+                  onChange={formik.handleChange}
+                  onBlur={() => {
+                    if (formik.values.version && formik.values.name) {
+                      formik.submitForm();
+                    }
+                  }}
+                />
+                {isAppNameError && (
+                  <FormErrorMessage>Application name can not be empty</FormErrorMessage>
+                )}
+              </VStack>
+            </HStack>
+          </FormControl>
+        </HStack>
       </VStack>
     );
   }

--- a/packages/editor/src/components/Explorer/ExplorerForm/ExplorerForm.tsx
+++ b/packages/editor/src/components/Explorer/ExplorerForm/ExplorerForm.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { observer } from 'mobx-react-lite';
-import { Button, Text, VStack } from '@chakra-ui/react';
-import { ArrowLeftIcon } from '@chakra-ui/icons';
+import { VStack } from '@chakra-ui/react';
 import { AppMetaDataForm, AppMetaDataFormData } from './AppMetaDataForm';
 import { ModuleMetaDataForm, ModuleMetaDataFormData } from './ModuleMetaDataForm';
 import { EditorServices } from '../../../types';
@@ -13,12 +12,11 @@ type Props = {
   name: string;
   setCurrentVersion?: (version: string) => void;
   setCurrentName?: (name: string) => void;
-  onBack: () => void;
   services: EditorServices;
 };
 
 export const ExplorerForm: React.FC<Props> = observer(
-  ({ formType, version, name, setCurrentVersion, setCurrentName, onBack, services }) => {
+  ({ formType, version, name, setCurrentVersion, setCurrentName, services }) => {
     const { editorStore } = services;
     const onSubmit = (value: AppMetaDataFormData | ModuleMetaDataFormData) => {
       setCurrentVersion?.(value.version);
@@ -45,6 +43,7 @@ export const ExplorerForm: React.FC<Props> = observer(
           stateMap: moduleSpec?.spec.stateMap || {},
           properties: moduleSpec?.spec.properties || Type.Object({}),
           exampleProperties: moduleSpec?.metadata.exampleProperties || {},
+          events: moduleSpec?.spec.events || [],
         };
         form = (
           <ModuleMetaDataForm
@@ -56,21 +55,7 @@ export const ExplorerForm: React.FC<Props> = observer(
         break;
     }
     return (
-      <VStack alignItems="start">
-        <Button
-          aria-label="go back to tree"
-          size="sm"
-          leftIcon={<ArrowLeftIcon />}
-          variant="ghost"
-          colorScheme="blue"
-          onClick={onBack}
-          padding="0"
-        >
-          Back
-        </Button>
-        <Text fontSize="lg" fontWeight="bold">
-          {formType === 'app' ? 'Application' : 'Module'}
-        </Text>
+      <VStack w="full" alignItems="start">
         {form}
       </VStack>
     );

--- a/packages/editor/src/components/Explorer/ExplorerForm/ModuleMetaDataForm.tsx
+++ b/packages/editor/src/components/Explorer/ExplorerForm/ModuleMetaDataForm.tsx
@@ -123,7 +123,7 @@ export const ModuleMetaDataForm: React.FC<ModuleMetaDataFormProps> = observer(
                   }}
                 />
                 {isModuleVersionError && (
-                  <FormErrorMessage>Module name can not be empty</FormErrorMessage>
+                  <FormErrorMessage>Module version can not be empty</FormErrorMessage>
                 )}
               </VStack>
             </HStack>

--- a/packages/editor/src/components/Explorer/ExplorerForm/ModuleMetaDataForm.tsx
+++ b/packages/editor/src/components/Explorer/ExplorerForm/ModuleMetaDataForm.tsx
@@ -22,9 +22,7 @@ export type ModuleMetaDataFormData = {
   version: string;
   stateMap: Record<string, string>;
   properties: JSONSchema7;
-  events: {
-    name: string;
-  }[];
+  events: string[];
   exampleProperties: JSONSchema7Object;
 };
 
@@ -34,12 +32,11 @@ type ModuleMetaDataFormProps = {
   onSubmit?: (value: ModuleMetaDataFormData) => void;
 };
 
-const genEventsName = (events: { name: string }[]) => {
+const genEventsName = (events: string[]) => {
   let count = events.length;
   let name = `event${count}`;
-  const eventNames = events.map(({ name }) => name);
 
-  while (eventNames.includes(name)) {
+  while (events.includes(name)) {
     name = `event${++count}`;
   }
 
@@ -48,7 +45,7 @@ const genEventsName = (events: { name: string }[]) => {
 
 const EventInput: React.FC<{
   name: string;
-  events: { name: string }[];
+  events: string[];
   index: number;
   onChange: (value: string) => void;
 }> = ({ name: defaultName, onChange, events, index }) => {
@@ -69,7 +66,7 @@ const EventInput: React.FC<{
         onBlur={() => {
           const newEvents = [...events];
           newEvents.splice(index, 1);
-          if (newEvents.find(e => e.name === name)) {
+          if (newEvents.find(eventName => eventName === name)) {
             setIsRepeated(true);
             return;
           }
@@ -173,20 +170,20 @@ export const ModuleMetaDataForm: React.FC<ModuleMetaDataFormProps> = observer(
         </FormControl>
         <FormControl>
           <FormLabel>Events</FormLabel>
-          {formik.values.events.map((event, i) => {
+          {formik.values.events.map((eventName, i) => {
             return (
-              <HStack m="10px 0 10px 0" alignItems="normal" key={event.name}>
+              <HStack m="10px 0 10px 0" alignItems="normal" key={eventName}>
                 <EventInput
                   events={formik.values.events}
                   index={i}
                   onChange={newName => {
                     const newEvents = produce(formik.values.events, draft => {
-                      draft[i].name = newName;
+                      draft[i] = newName;
                     });
                     formik.setFieldValue('events', newEvents);
                     formik.submitForm();
                   }}
-                  name={event.name}
+                  name={eventName}
                 />
                 <IconButton
                   aria-label="remove row"
@@ -207,9 +204,7 @@ export const ModuleMetaDataForm: React.FC<ModuleMetaDataFormProps> = observer(
           <Button
             onClick={() => {
               const newEvents = produce(formik.values.events, draft => {
-                draft.push({
-                  name: genEventsName(draft),
-                });
+                draft.push(genEventsName(draft));
               });
               formik.setFieldValue('events', newEvents);
               formik.submitForm();

--- a/packages/editor/src/components/Explorer/ExplorerForm/ModuleMetaDataForm.tsx
+++ b/packages/editor/src/components/Explorer/ExplorerForm/ModuleMetaDataForm.tsx
@@ -1,34 +1,30 @@
-import React, { Suspense } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
-  Box,
   Button,
   FormControl,
   FormLabel,
   Input,
-  Modal,
-  ModalBody,
-  ModalCloseButton,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
-  useDisclosure,
   VStack,
+  IconButton,
+  HStack,
+  FormErrorMessage,
 } from '@chakra-ui/react';
-import { RecordEditor, SpecWidget } from '@sunmao-ui/editor-sdk';
+import { RecordEditor } from '@sunmao-ui/editor-sdk';
 import { useFormik } from 'formik';
 import { observer } from 'mobx-react-lite';
 import { EditorServices } from '../../../types';
-import { generateDefaultValueFromSpec } from '@sunmao-ui/shared';
 import { JSONSchema7, JSONSchema7Object } from 'json-schema';
-
-const JsonSchemaEditor = React.lazy(() => import('@optum/json-schema-editor'));
+import { CloseIcon } from '@chakra-ui/icons';
+import produce from 'immer';
 
 export type ModuleMetaDataFormData = {
   name: string;
   version: string;
   stateMap: Record<string, string>;
   properties: JSONSchema7;
+  events: {
+    name: string;
+  }[];
   exampleProperties: JSONSchema7Object;
 };
 
@@ -38,9 +34,59 @@ type ModuleMetaDataFormProps = {
   onSubmit?: (value: ModuleMetaDataFormData) => void;
 };
 
+const genEventsName = (events: { name: string }[]) => {
+  let count = events.length;
+  let name = `event${count}`;
+  const eventNames = events.map(({ name }) => name);
+
+  while (eventNames.includes(name)) {
+    name = `event${++count}`;
+  }
+
+  return `event${count}`;
+};
+
+const EventInput: React.FC<{
+  name: string;
+  events: { name: string }[];
+  index: number;
+  onChange: (value: string) => void;
+}> = ({ name: defaultName, onChange, events, index }) => {
+  const [name, setName] = useState(defaultName);
+  const [isRepeated, setIsRepeated] = useState(false);
+
+  useEffect(() => {
+    setName(defaultName);
+  }, [defaultName]);
+
+  return (
+    <FormControl w="33.33%" isInvalid={isRepeated}>
+      <Input
+        name="name"
+        onChange={e => {
+          setName(e.target.value);
+        }}
+        onBlur={() => {
+          const newEvents = [...events];
+          newEvents.splice(index, 1);
+          if (newEvents.find(e => e.name === name)) {
+            setIsRepeated(true);
+            return;
+          }
+          setIsRepeated(false);
+          onChange(name);
+        }}
+        value={name}
+      />
+      <FormErrorMessage mt="0" pl="10px">
+        event name already exists
+      </FormErrorMessage>
+    </FormControl>
+  );
+};
+
 export const ModuleMetaDataForm: React.FC<ModuleMetaDataFormProps> = observer(
   ({ initData, services, onSubmit: onSubmitForm }) => {
-    const { isOpen, onOpen, onClose } = useDisclosure();
     const { editorStore } = services;
 
     const onSubmit = (value: ModuleMetaDataFormData) => {
@@ -57,35 +103,52 @@ export const ModuleMetaDataForm: React.FC<ModuleMetaDataFormProps> = observer(
       onSubmit,
     });
 
-    const moduleSpec = formik.values.properties;
-
-    const moduleProperties = {
-      ...(generateDefaultValueFromSpec(moduleSpec) as JSONSchema7Object),
-      ...formik.values.exampleProperties,
-    };
-
-    const moduleSpecs = (moduleSpec.properties || {}) as Record<string, JSONSchema7>;
-
+    const isModuleVersionError = formik.values.version === '';
+    const isModuleNameError = formik.values.name === '';
     return (
-      <VStack>
-        <FormControl isRequired>
-          <FormLabel>Module Version</FormLabel>
-          <Input
-            name="version"
-            value={formik.values.version}
-            onChange={formik.handleChange}
-            onBlur={() => formik.submitForm()}
-          />
-        </FormControl>
-        <FormControl isRequired>
-          <FormLabel>Module Name</FormLabel>
-          <Input
-            name="name"
-            value={formik.values.name}
-            onChange={formik.handleChange}
-            onBlur={() => formik.submitForm()}
-          />
-        </FormControl>
+      <VStack w="full" spacing="5">
+        <HStack w="full" align="normal">
+          <FormControl isInvalid={isModuleVersionError}>
+            <HStack align="normal">
+              <FormLabel>Version</FormLabel>
+              <VStack w="full" align="normal">
+                <Input
+                  name="version"
+                  value={formik.values.version}
+                  onChange={formik.handleChange}
+                  onBlur={() => {
+                    if (formik.values.version && formik.values.name) {
+                      formik.submitForm();
+                    }
+                  }}
+                />
+                {isModuleVersionError && (
+                  <FormErrorMessage>Module name can not be empty</FormErrorMessage>
+                )}
+              </VStack>
+            </HStack>
+          </FormControl>
+          <FormControl isInvalid={isModuleNameError}>
+            <HStack align="normal">
+              <FormLabel>Name</FormLabel>
+              <VStack w="full" align="normal">
+                <Input
+                  name="name"
+                  value={formik.values.name}
+                  onChange={formik.handleChange}
+                  onBlur={() => {
+                    if (formik.values.version && formik.values.name) {
+                      formik.submitForm();
+                    }
+                  }}
+                />
+                {isModuleNameError && (
+                  <FormErrorMessage>Module name can not be empty</FormErrorMessage>
+                )}
+              </VStack>
+            </HStack>
+          </FormControl>
+        </HStack>
         <FormControl>
           <FormLabel>Module StateMap</FormLabel>
           <RecordEditor
@@ -98,75 +161,64 @@ export const ModuleMetaDataForm: React.FC<ModuleMetaDataFormProps> = observer(
           />
         </FormControl>
         <FormControl>
-          <Button onClick={onOpen}>Edit Spec</Button>
-          <Modal
-            isOpen={isOpen}
-            onClose={onClose}
-            size="900px"
-            closeOnEsc={false}
-            trapFocus={false}
-          >
-            <ModalOverlay />
-            <ModalContent w="900px">
-              <ModalHeader>Module Spec</ModalHeader>
-              <ModalCloseButton />
-              <ModalBody overflow="auto">
-                {isOpen && (
-                  <Box>
-                    <Suspense fallback="Loading Spec Editor">
-                      <JsonSchemaEditor
-                        data={moduleSpec}
-                        onSchemaChange={s => {
-                          const curSpec = JSON.parse(s);
-                          if (
-                            s === JSON.stringify(moduleSpec) ||
-                            curSpec.type === 'array'
-                          )
-                            return;
-
-                          formik.setFieldValue('properties', curSpec);
-                        }}
-                      />
-                    </Suspense>
-                  </Box>
-                )}
-              </ModalBody>
-              <ModalFooter>
-                <Button
-                  colorScheme="blue"
-                  onClick={() => {
-                    onClose();
-                    formik.submitForm();
-                  }}
-                >
-                  Save
-                </Button>
-              </ModalFooter>
-            </ModalContent>
-          </Modal>
+          <FormLabel>Properties</FormLabel>
+          <RecordEditor
+            services={services}
+            value={formik.values.exampleProperties}
+            onChange={json => {
+              formik.setFieldValue('exampleProperties', json);
+              formik.submitForm();
+            }}
+          />
         </FormControl>
         <FormControl>
-          <FormLabel>Properties</FormLabel>
-          {Object.keys(moduleSpecs).map(key => {
+          <FormLabel>Events</FormLabel>
+          {formik.values.events.map((event, i) => {
             return (
-              <SpecWidget
-                key={key}
-                spec={{ ...moduleSpecs[key], title: moduleSpecs[key].title || key }}
-                value={moduleProperties[key]}
-                path={[]}
-                component={{} as any}
-                level={1}
-                services={services}
-                onChange={newFormData => {
-                  formik.setFieldValue('exampleProperties', {
-                    ...moduleProperties,
-                    [key]: newFormData,
-                  });
-                  formik.submitForm();
-                }}
-              />
+              <HStack m="10px 0 10px 0" alignItems="normal" key={event.name}>
+                <EventInput
+                  events={formik.values.events}
+                  index={i}
+                  onChange={newName => {
+                    const newEvents = produce(formik.values.events, draft => {
+                      draft[i].name = newName;
+                    });
+                    formik.setFieldValue('events', newEvents);
+                    formik.submitForm();
+                  }}
+                  name={event.name}
+                />
+                <IconButton
+                  aria-label="remove row"
+                  icon={<CloseIcon />}
+                  size="xs"
+                  onClick={() => {
+                    const newEvents = produce(formik.values.events, draft => {
+                      draft.splice(i, 1);
+                    });
+                    formik.setFieldValue('events', newEvents);
+                    formik.submitForm();
+                  }}
+                  variant="ghost"
+                />
+              </HStack>
             );
           })}
+          <Button
+            onClick={() => {
+              const newEvents = produce(formik.values.events, draft => {
+                draft.push({
+                  name: genEventsName(draft),
+                });
+              });
+              formik.setFieldValue('events', newEvents);
+              formik.submitForm();
+            }}
+            size="xs"
+            alignSelf="start"
+          >
+            + Add
+          </Button>
         </FormControl>
       </VStack>
     );

--- a/packages/editor/src/services/AppStorage.ts
+++ b/packages/editor/src/services/AppStorage.ts
@@ -116,12 +116,14 @@ export class AppStorage {
       stateMap,
       properties,
       exampleProperties,
+      events,
     }: {
       version: string;
       name: string;
       stateMap: Record<string, string>;
       properties: JSONSchema7;
       exampleProperties: JSONSchema7Object;
+      events: { name: string }[];
     }
   ) {
     const i = this.modules.findIndex(
@@ -133,6 +135,7 @@ export class AppStorage {
       draft[i].spec.stateMap = stateMap;
       draft[i].spec.properties = properties;
       draft[i].version = version;
+      draft[i].spec.events = events;
     });
 
     this.setModules(newModules);

--- a/packages/editor/src/services/AppStorage.ts
+++ b/packages/editor/src/services/AppStorage.ts
@@ -123,7 +123,7 @@ export class AppStorage {
       stateMap: Record<string, string>;
       properties: JSONSchema7;
       exampleProperties: JSONSchema7Object;
-      events: { name: string }[];
+      events: string[];
     }
   ) {
     const i = this.modules.findIndex(


### PR DESCRIPTION
![module form](https://user-images.githubusercontent.com/96771399/211699174-f143ffe2-f0ee-4732-bcbf-803619c74c78.gif)

The update contains the following

1.  module and app edit forms changed to modal
2. no longer use `spec.properties`, no longer support manual editing of module spec, remove edit spec button
3. `exampleProperties` are now displayed using `recordWidget`
4. add module event edit form
5. module properties type in Module widget is inferred from exampleProperties to generate specs