### PR TITLE
fix(arco/Select): when defaultValue is empty, it is handled as undefined

### DIFF
--- a/packages/arco-lib/src/components/Select.tsx
+++ b/packages/arco-lib/src/components/Select.tsx
@@ -74,7 +74,7 @@ export const Select = implementRuntimeComponent({
     customStyle,
     callbackMap,
     mergeState,
-    defaultValue = '',
+    defaultValue,
     subscribeMethods,
   } = props;
   const {
@@ -92,7 +92,7 @@ export const Select = implementRuntimeComponent({
   } = getComponentProps(props);
 
   const [value, setValue] = useStateValue(
-    defaultValue,
+    defaultValue || undefined,
     mergeState,
     updateWhenDefaultValueChanges,
     undefined,


### PR DESCRIPTION
When the value passed to the select component is `''`, it causes the placeholder to not be displayed. After some consideration, it was decided that the default value of '' would be handled as undefined