### PR TITLE
fix: popover widget will not close after clickoutside

### DIFF
--- a/packages/editor-sdk/src/components/Widgets/PopoverWidget.tsx
+++ b/packages/editor-sdk/src/components/Widgets/PopoverWidget.tsx
@@ -142,8 +142,9 @@ export const PopoverWidget = React.forwardRef<
   }, [handlerCloseByParent, handlerCloseByOther]);
   useEffect(() => {
     const handleClickOutside = (event: any) => {
+      const eventPath = event.path || (event.composedPath && event.composedPath()) || [];
       if (
-        event.path.some((node: Element) =>
+        eventPath.some((node: Element) =>
           [...(node.classList?.values() || [])].includes(
             PREVENT_POPOVER_WIDGET_CLOSE_CLASS
           )


### PR DESCRIPTION
<img width="1677" alt="截屏2023-01-19 下午1 57 47" src="https://user-images.githubusercontent.com/12260952/213366824-38d1f3dd-5daf-4637-8623-5459c14e499d.png">

Solve according to this: https://stackoverflow.com/questions/39245488/event-path-is-undefined-running-in-firefox