### PR TITLE
refactor(runtime): watch property change on properties level

### DIFF
--- a/packages/runtime/src/services/StateManager.ts
+++ b/packages/runtime/src/services/StateManager.ts
@@ -1,6 +1,5 @@
-import { mapValues, isArray, set } from 'lodash';
+import { mapValues, isArray } from 'lodash';
 import dayjs from 'dayjs';
-import produce from 'immer';
 import 'dayjs/locale/zh-cn';
 import isLeapYear from 'dayjs/plugin/isLeapYear';
 import relativeTime from 'dayjs/plugin/relativeTime';
@@ -208,30 +207,16 @@ export class StateManager {
     };
     // watch change
     if (value && typeof value === 'object') {
-      let resultCache = evaluated as PropsAfterEvaled<Exclude<T, string>>;
-
-      this.mapValuesDeep(value, ({ value, path }) => {
-        const isDynamicExpression =
-          typeof value === 'string' &&
-          parseExpression(value).some(exp => typeof exp !== 'string');
-
-        if (!isDynamicExpression) return;
-
-        const stop = watch(
-          () => {
-            const result = this._maskedEval(value as string, options);
-
-            return result;
-          },
-          newV => {
-            resultCache = produce(resultCache, draft => {
-              set(draft, path, newV);
-            });
-            watcher({ result: resultCache as EvaledResult<T> });
-          }
-        );
-        stops.push(stop);
-      });
+      const stop = watch(
+        () => {
+          const result = this.deepEval(value);
+          return result;
+        },
+        newV => {
+          watcher({ result: newV as EvaledResult<T> });
+        }
+      );
+      stops.push(stop);
     } else {
       const stop = watch(
         () => {
@@ -240,9 +225,6 @@ export class StateManager {
         },
         newV => {
           watcher({ result: newV as EvaledResult<T> });
-        },
-        {
-          deep: true,
         }
       );
       stops.push(stop);


### PR DESCRIPTION
To avoid run traits and components multiple times when they use same value in property expressions.