### PR TITLE
Revert eval property in object level

### DIFF
--- a/packages/runtime/src/services/StateManager.ts
+++ b/packages/runtime/src/services/StateManager.ts
@@ -209,7 +209,7 @@ export class StateManager {
     if (value && typeof value === 'object') {
       const stop = watch(
         () => {
-          const result = this.deepEval(value, options);
+          const result = this.deepEval(value);
           return result;
         },
         newV => {


### PR DESCRIPTION
`StateManager` used to watch change in expression level and update the result by immerjs. But if `StateManager` used to watch change in object level, we cannot add this immerjs logic, which will cause unexpected bug.
So we decide to revert this change.