### PR TITLE
fix(arco/Radio): defaultValue use the expression widget

### DIFF
--- a/packages/arco-lib/src/generated/types/Radio.ts
+++ b/packages/arco-lib/src/generated/types/Radio.ts
@@ -24,6 +24,7 @@ export const RadioPropsSpec = {
   defaultCheckedValue: Type.Union(radioValueType, {
     title: 'Default Value',
     category: Category.Basic,
+    widget: 'core/v1/expression',
   }),
   type: StringUnion(['radio', 'button'], {
     title: 'Type',


### PR DESCRIPTION
Since there is no perfect conversion when switching expressions to bool/number/string, the expression widget is used for the time being to represent the union value