### PR TITLE
Fix/arco table

### DIFF
--- a/packages/arco-lib/src/components/Table/Table.tsx
+++ b/packages/arco-lib/src/components/Table/Table.tsx
@@ -215,7 +215,7 @@ export const Table = implementRuntimeComponent({
   } = pagination;
 
   const rowSelectionType = rowSelectionTypeMap[cProps.rowSelectionType];
-  const currentChecked = useRef<any[]>([]);
+  const currentChecked = useRef<Record<string, unknown>[]>([]);
   const currentClickedRow = useRef<(string | number)[] | undefined>(undefined);
 
   const [currentPage, setCurrentPage] = useStateValue<number>(
@@ -274,7 +274,9 @@ export const Table = implementRuntimeComponent({
 
   // reset selectedRows state when data changed
   useEffect(() => {
-    const currentCheckedRowKeys = currentChecked.current.map(row => row[rowKey]);
+    const currentCheckedRowKeys = currentChecked.current.map(
+      row => row[rowKey] as string
+    );
     // TODO: Save clickedRow state when rowkey changes, save the UI of clickedRow when turning the page
     const clickedRow = currentPageData.find(d => d[rowKey] === currentClickedRow.current);
     if (!clickedRow) currentClickedRow.current = undefined;

--- a/packages/arco-lib/src/components/Table/Table.tsx
+++ b/packages/arco-lib/src/components/Table/Table.tsx
@@ -215,7 +215,7 @@ export const Table = implementRuntimeComponent({
   } = pagination;
 
   const rowSelectionType = rowSelectionTypeMap[cProps.rowSelectionType];
-  const currentChecked = useRef<(string | number)[]>([]);
+  const currentChecked = useRef<any[]>([]);
   const currentClickedRow = useRef<(string | number)[] | undefined>(undefined);
 
   const [currentPage, setCurrentPage] = useStateValue<number>(
@@ -274,15 +274,13 @@ export const Table = implementRuntimeComponent({
 
   // reset selectedRows state when data changed
   useEffect(() => {
-    const selectedRows = currentPageData.filter(d =>
-      currentChecked.current.includes(d[rowKey])
-    );
+    const currentCheckedRowKeys = currentChecked.current.map(row => row[rowKey]);
     // TODO: Save clickedRow state when rowkey changes, save the UI of clickedRow when turning the page
     const clickedRow = currentPageData.find(d => d[rowKey] === currentClickedRow.current);
     if (!clickedRow) currentClickedRow.current = undefined;
     mergeState({
-      selectedRowKeys: selectedRows.map(r => r[rowKey]),
-      selectedRows,
+      selectedRowKeys: currentCheckedRowKeys,
+      selectedRows: currentChecked.current,
       clickedRow,
     });
   }, [currentPageData, mergeState, rowKey]);
@@ -573,7 +571,7 @@ export const Table = implementRuntimeComponent({
         // This option is required to achieve multi-selection across pages when customizing paging
         preserveSelectedRowKeys: useCustomPagination ? checkCrossPage : undefined,
         onChange(selectedRowKeys, selectedRows) {
-          currentChecked.current = selectedRowKeys;
+          currentChecked.current = selectedRows;
           mergeState({
             selectedRowKeys: selectedRowKeys as string[],
             selectedRows,

--- a/packages/arco-lib/src/generated/types/Table.ts
+++ b/packages/arco-lib/src/generated/types/Table.ts
@@ -367,7 +367,8 @@ export const TablePropsSpec = Type.Object({
   checkCrossPage: Type.Boolean({
     title: 'Check Cross Page',
     category: Category.Basic,
-    description: 'Whether the checkboxes in multi-select mode cross pages',
+    description:
+      'Whether the checkboxes in multi-select mode cross pages。Please note that with this option on, if the data changes, the previous selected state will still be cached',
   }),
   rowSelectionType: StringUnion(['multiple', 'single', 'disable'], {
     title: 'Row Selection Type',

--- a/packages/arco-lib/src/widgets/TablePrimaryKeyWidget.tsx
+++ b/packages/arco-lib/src/widgets/TablePrimaryKeyWidget.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { WidgetProps, implementWidget } from '@sunmao-ui/editor-sdk';
+import { WidgetProps, implementWidget, isExpression } from '@sunmao-ui/editor-sdk';
 import { ColumnSpec } from '../generated/types/Table';
 import { Static } from '@sinclair/typebox';
 import { Select } from '@arco-design/web-react';
@@ -10,9 +10,13 @@ type TablePrimaryKeyWidgetID = 'arco/v1/primaryKey';
 export const _TablePrimaryKeyWidget: React.FC<
   WidgetProps<TablePrimaryKeyWidgetID, string>
 > = props => {
-  const { value, onChange, component } = props;
+  const { value, onChange, component, services } = props;
   const { properties } = component;
-  const columns = properties.columns as Static<typeof ColumnSpec>[];
+  const columns = (
+    isExpression(properties.columns)
+      ? services.stateManager.deepEval(properties.columns as string)
+      : properties.columns
+  ) as Static<typeof ColumnSpec>[];
 
   const keys = columns.map(c => c.dataIndex);
 


### PR DESCRIPTION
1. fix the problem that the `selectedRows` state was not synchronized correctly when the data changes when `checkCrossPage` is enabled for server-side paging
2. fix an error in tablePrimaryKeyWidget when columns is expression