### PR TITLE
Support module method

### DIFF
--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -13,11 +13,17 @@ export type Module = {
   impl: ComponentSchema[];
 };
 
+export type ModuleMethodSpec = {
+  name: string;
+  componentId: string;
+  componentMethod: string;
+};
+
 type ModuleSpec = {
   properties: JSONSchema7;
   events: string[];
   stateMap: Record<string, string>;
-  methods: { name: string; componentId: string; componentMethod: string }[];
+  methods: ModuleMethodSpec[];
 };
 
 // extended runtime

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -17,6 +17,7 @@ type ModuleSpec = {
   properties: JSONSchema7;
   events: string[];
   stateMap: Record<string, string>;
+  methods: { name: string; componentId: string; componentMethod: string }[];
 };
 
 // extended runtime
@@ -46,6 +47,7 @@ export function createModule(options: CreateModuleOptions): RuntimeModule {
       properties: { type: 'object' },
       events: [],
       stateMap: {},
+      methods: [],
       ...options.spec,
     },
     impl: options.impl || [],

--- a/packages/editor/src/components/Explorer/ExplorerForm/ExplorerForm.tsx
+++ b/packages/editor/src/components/Explorer/ExplorerForm/ExplorerForm.tsx
@@ -6,6 +6,7 @@ import { ModuleMetaDataForm, ModuleMetaDataFormData } from './ModuleMetaDataForm
 import { EditorServices } from '../../../types';
 import { Type } from '@sinclair/typebox';
 import { cloneDeep } from 'lodash';
+import { json2JsonSchema } from '@sunmao-ui/editor-sdk';
 
 type Props = {
   formType: 'app' | 'module';
@@ -30,9 +31,12 @@ export const ExplorerForm: React.FC<Props> = observer(
     };
     const saveModuleMetaData = () => {
       if (!newModuleMetaDataRef.current) return;
+      const propertiesSpec = json2JsonSchema(
+        services.stateManager.deepEval(newModuleMetaDataRef.current.exampleProperties)
+      );
       editorStore.appStorage.saveModuleMetaData(
         { originName: name, originVersion: version },
-        newModuleMetaDataRef.current
+        { ...newModuleMetaDataRef.current, properties: propertiesSpec }
       );
       editorStore.setModuleDependencies(newModuleMetaDataRef.current.exampleProperties);
       setCurrentVersion?.(newModuleMetaDataRef.current.version);
@@ -85,6 +89,7 @@ export const ExplorerForm: React.FC<Props> = observer(
           properties: moduleSpec?.spec.properties || Type.Object({}),
           exampleProperties: moduleSpec?.metadata.exampleProperties || {},
           events: moduleSpec?.spec.events || [],
+          methods: moduleSpec?.spec.methods || [],
         });
         form = (
           <ModuleMetaDataForm

--- a/packages/editor/src/components/Explorer/ExplorerForm/ModuleMetaDataForm.tsx
+++ b/packages/editor/src/components/Explorer/ExplorerForm/ModuleMetaDataForm.tsx
@@ -10,18 +10,22 @@ import {
   FormErrorMessage,
 } from '@chakra-ui/react';
 import { RecordEditor } from '@sunmao-ui/editor-sdk';
+import { ModuleMethodSpec } from '@sunmao-ui/core';
 import { useFormik } from 'formik';
 import { observer } from 'mobx-react-lite';
 import { EditorServices } from '../../../types';
 import { JSONSchema7Object } from 'json-schema';
 import { CloseIcon } from '@chakra-ui/icons';
 import produce from 'immer';
+import { CodeEditor } from '../../CodeEditor';
+import { css } from '@emotion/css';
 
 export type ModuleMetaDataFormData = {
   name: string;
   version: string;
   stateMap: Record<string, string>;
   events: string[];
+  methods: ModuleMethodSpec[];
   exampleProperties: JSONSchema7Object;
 };
 
@@ -206,6 +210,25 @@ export const ModuleMetaDataForm: React.FC<ModuleMetaDataFormProps> = observer(
           >
             + Add
           </Button>
+        </FormControl>
+        <FormControl>
+          <FormLabel>Methods</FormLabel>
+          <CodeEditor
+            className={css`
+              width: 100%;
+              height: 120px;
+            `}
+            mode="json"
+            defaultCode={JSON.stringify(formik.values.methods)}
+            onBlur={v => {
+              try {
+                const newMethods = JSON.parse(v);
+                formik.setFieldValue('methods', newMethods);
+                formik.submitForm();
+              } catch {}
+            }}
+            needRerenderAfterMount
+          />
         </FormControl>
       </VStack>
     );

--- a/packages/editor/src/components/Explorer/ExplorerForm/ModuleMetaDataForm.tsx
+++ b/packages/editor/src/components/Explorer/ExplorerForm/ModuleMetaDataForm.tsx
@@ -13,7 +13,7 @@ import { RecordEditor } from '@sunmao-ui/editor-sdk';
 import { useFormik } from 'formik';
 import { observer } from 'mobx-react-lite';
 import { EditorServices } from '../../../types';
-import { JSONSchema7, JSONSchema7Object } from 'json-schema';
+import { JSONSchema7Object } from 'json-schema';
 import { CloseIcon } from '@chakra-ui/icons';
 import produce from 'immer';
 
@@ -21,7 +21,6 @@ export type ModuleMetaDataFormData = {
   name: string;
   version: string;
   stateMap: Record<string, string>;
-  properties: JSONSchema7;
   events: string[];
   exampleProperties: JSONSchema7Object;
 };

--- a/packages/editor/src/components/ExtractModuleModal/ExtractModuleView.tsx
+++ b/packages/editor/src/components/ExtractModuleModal/ExtractModuleView.tsx
@@ -255,7 +255,7 @@ export const ExtractModuleView: React.FC<Props> = ({
     if (!genModuleResult || !moduleFormValueRef.current) return;
     services.editorStore.appStorage.createModule({
       components: genModuleResult.moduleComponentsSchema,
-      propertySpec: moduleFormValueRef.current.properties,
+      propertySpec: json2JsonSchema(genModuleResult.exampleProperties),
       exampleProperties: genModuleResult.exampleProperties,
       events: genModuleResult.eventSpec,
       moduleVersion: moduleFormValueRef.current.version,
@@ -289,9 +289,9 @@ export const ExtractModuleView: React.FC<Props> = ({
         name: componentId,
         version: 'custom/v1',
         stateMap: result.stateMap,
-        properties: json2JsonSchema(result.exampleProperties),
         events: result.eventSpec,
         exampleProperties: result.exampleProperties,
+        methods: [],
       };
       setModuleFormInitData(moduleFormData);
       moduleFormValueRef.current = moduleFormData;

--- a/packages/editor/src/constants/index.ts
+++ b/packages/editor/src/constants/index.ts
@@ -40,6 +40,7 @@ export const DefaultNewModule: ImplementedRuntimeModule = {
     stateMap: {},
     events: [],
     properties: { type: 'object', properties: {} },
+    methods: [],
   },
   impl: [
     {

--- a/packages/editor/src/services/AppStorage.ts
+++ b/packages/editor/src/services/AppStorage.ts
@@ -3,6 +3,7 @@ import {
   Application,
   ComponentSchema,
   Module,
+  ModuleMethodSpec,
   parseVersion,
   RuntimeModule,
 } from '@sunmao-ui/core';
@@ -167,6 +168,7 @@ export class AppStorage {
       properties,
       exampleProperties,
       events,
+      methods,
     }: {
       version: string;
       name: string;
@@ -174,6 +176,7 @@ export class AppStorage {
       properties: JSONSchema7;
       exampleProperties: JSONSchema7Object;
       events: string[];
+      methods: ModuleMethodSpec[];
     }
   ) {
     const i = this.modules.findIndex(
@@ -186,6 +189,7 @@ export class AppStorage {
       draft[i].spec.properties = properties;
       draft[i].version = version;
       draft[i].spec.events = events;
+      draft[i].spec.methods = methods;
     });
 
     this.setModules(newModules);

--- a/packages/editor/src/utils/addModuleId.ts
+++ b/packages/editor/src/utils/addModuleId.ts
@@ -53,6 +53,7 @@ export function addModuleId(originModule: Module): Module {
     traverse(module.impl);
     // value of stateMap is expression, not property
     traverse(module.spec.stateMap, true);
+    traverse(module.spec.methods, true);
   });
 }
 
@@ -72,6 +73,7 @@ export function removeModuleId(originModule: Module): Module {
 
     traverse(module.impl);
     traverse(module.spec.stateMap);
+    traverse(module.spec.methods);
   });
 }
 

--- a/packages/runtime/src/components/_internal/ModuleRenderer.tsx
+++ b/packages/runtime/src/components/_internal/ModuleRenderer.tsx
@@ -78,7 +78,6 @@ const ModuleRendererContent = React.forwardRef<
   }, [services.stateManager, moduleSpec.spec.stateMap, moduleId]);
 
   // then eval the methods a of module
-  console.log('moduleSpec.spec.method', moduleSpec.spec.methods);
   const evaledMethods = useMemo(() => {
     return services.stateManager.deepEval(
       { result: moduleSpec.spec.methods },
@@ -174,13 +173,10 @@ const ModuleRendererContent = React.forwardRef<
 
   // listen methods calling
   useEffect(() => {
-    console.log('evaledMethods', evaledMethods);
     const methodHandlers: Array<(payload: UIMethodPayload) => void> = [];
     evaledMethods.forEach(methodMap => {
       const handler = (payload: UIMethodPayload) => {
-        console.log('监听到了', payload);
         if (payload.componentId === containerId && payload.name === methodMap.name) {
-          console.log('发出去了');
           services.apiService.send('uiMethod', {
             ...payload,
             componentId: methodMap.componentId,
@@ -198,7 +194,7 @@ const ModuleRendererContent = React.forwardRef<
         services.apiService.off('uiMethod', h);
       });
     };
-  }, [evaledMethods, services.apiService]);
+  }, [containerId, evaledMethods, services.apiService]);
 
   const result = useMemo(() => {
     // Must init components' state, otherwise store cannot listen these components' state changing

--- a/packages/runtime/src/components/core/ModuleContainer.tsx
+++ b/packages/runtime/src/components/core/ModuleContainer.tsx
@@ -77,6 +77,7 @@ export default implementRuntimeComponent({
         services={services}
         app={app}
         ref={elementRef}
+        containerId={component.id}
       />
     );
   }

--- a/packages/runtime/src/services/apiService.ts
+++ b/packages/runtime/src/services/apiService.ts
@@ -1,23 +1,26 @@
 import mitt from 'mitt';
 export type ApiService = ReturnType<typeof initApiService>;
 
+/**
+ * @description: trigger component's method
+ * @example: { componentId: "btn1", name: "click" }
+ */
+export type UIMethodPayload = {
+  componentId: string;
+  name: string;
+  triggerId: string;
+  eventType: string;
+  parameters?: any;
+};
+
+export type ModuleEventPayload = {
+  fromId: string;
+  eventType: string;
+};
 export function initApiService() {
   const emitter = mitt<{
-    /**
-     * @description: trigger component's method
-     * @example: { componentId: "btn1", name: "click" }
-     */
-    uiMethod: {
-      componentId: string;
-      name: string;
-      triggerId: string;
-      eventType: string;
-      parameters?: any;
-    };
-    moduleEvent: {
-      fromId: string;
-      eventType: string;
-    };
+    uiMethod: UIMethodPayload;
+    moduleEvent: ModuleEventPayload;
     /**
      * @description: record merge state info for debug
      */

--- a/packages/shared/src/utils/check.ts
+++ b/packages/shared/src/utils/check.ts
@@ -1,9 +1,17 @@
-import { RuntimeTraitSchema } from '@sunmao-ui/core';
-import { CoreTraitName, CORE_VERSION } from '../constants';
+import { ComponentSchema, parseType, RuntimeTraitSchema } from '@sunmao-ui/core';
+import { CoreTraitName, CoreComponentName, CORE_VERSION } from '../constants';
 
 export function isEventTrait(trait: RuntimeTraitSchema) {
   return (
     trait.parsedType.version === CORE_VERSION &&
     trait.parsedType.name === CoreTraitName.Event
+  );
+}
+
+export function isModuleContainer(c: ComponentSchema) {
+  const parsedType = parseType(c.type);
+  return (
+    parsedType.version === CORE_VERSION &&
+    parsedType.name === CoreComponentName.ModuleContainer
   );
 }


### PR DESCRIPTION
# how to use?

Add module config in module's spec, like this:

```
  {
    "kind": "Module",
    "parsedVersion": { "category": "custom/v1", "value": "myModule" },
    "version": "custom/v1",
    "metadata": {
      "name": "myModule0",
      "description": "my module",
      "exampleProperties": {}
    },
    "spec": {
      "stateMap": {},
      "events": [],
      "properties": { "type": "object", "properties": {} },
      "methods": [
        {
          "name": "open",
          "componentId": "modal1",
          "componentMethod": "openModal"
        }
      ]
    },
```
 It works like a proxy. When other components calls `open` method on `ModuleContainer`, `ModuleRenderer` will call `modal1`'s `openModal` method.

https://user-images.githubusercontent.com/12260952/228761936-f665af4c-7cb6-40e6-8264-d40670d4e110.mov

