### PR TITLE
fix(ComponentSearch): use onSelect instead of onChange

### DIFF
--- a/packages/editor/src/components/StructureTree/ComponentSearch.tsx
+++ b/packages/editor/src/components/StructureTree/ComponentSearch.tsx
@@ -42,7 +42,7 @@ export const ComponentSearch: React.FC<Props> = observer(props => {
       bordered={false}
       className={SelectStyle}
       placeholder="Search component"
-      onChange={onChange}
+      onSelect={onChange}
       showArrow={false}
       showSearch
       style={{ width: '100%' }}


### PR DESCRIPTION
Previously using onChange would cause a bug:
1. enter anything in ComponentSearch, click and select an item in the dropdown . Jump to the corresponding component, as expected
2. select any other component in the component tree
3. repeat step 1, as no change in the input will not trigger onChange, resulting in selected item in componentSearch dropdown not jumping to the corresponding component

Fix: use onSelect instead of onChange to listen for changes each time it is selected