### PR TITLE
fix(collapse): fix infinite loop caused by defaultValue as an array

### DIFF
--- a/packages/arco-lib/src/hooks/useDeepCompareEffect.ts
+++ b/packages/arco-lib/src/hooks/useDeepCompareEffect.ts
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from 'react';
+import isEqual from 'lodash/isEqual';
+
+const useDeepCompareEffect = (
+  effect: React.EffectCallback,
+  deps: React.DependencyList
+) => {
+  const prevDeps = useRef<React.DependencyList | null>(null);
+
+  useEffect(() => {
+    if (prevDeps.current && !isEqual(deps, prevDeps.current)) {
+      effect();
+    }
+    prevDeps.current = deps;
+  }, [deps, effect]);
+};
+
+export default useDeepCompareEffect;

--- a/packages/arco-lib/src/hooks/useStateValue.ts
+++ b/packages/arco-lib/src/hooks/useStateValue.ts
@@ -1,6 +1,7 @@
 import { RuntimeFunctions } from '@sunmao-ui/runtime';
 import { useState, useEffect } from 'react';
 import { SlotSpec } from '@sunmao-ui/core';
+import useDeepCompareEffect from './useDeepCompareEffect';
 
 export const useStateValue = <
   T,
@@ -22,7 +23,7 @@ export const useStateValue = <
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     if (updateWhenDefaultValueChanges && mergeState) {
       setValue(defaultValue);
       mergeState({ [key]: defaultValue });


### PR DESCRIPTION
This commit fixes an issue in the Collapse component where using an array as the defaultValue prop could cause an infinite loop. The issue was caused by a shallow comparison of the defaultValue prop in the useStateValue hook.

To fix the issue, a new useDeepCompareEffect hook was added, which allows for deep comparison of the defaultValue prop. This hook uses the lodash isEqual function to compare arrays.