### PR TITLE
fix(Collapse): fix a dead loop caused by passing in a new array

### DIFF
--- a/packages/arco-lib/src/components/Collapse.tsx
+++ b/packages/arco-lib/src/components/Collapse.tsx
@@ -69,7 +69,7 @@ export const Collapse = implementRuntimeComponent({
   const { elementRef, mergeState, slotsElements, customStyle, callbackMap } = props;
 
   const [activeKey, setActiveKey] = useStateValue(
-    defaultActiveKey.map(String),
+    defaultActiveKey,
     mergeState,
     updateWhenDefaultValueChanges,
     'activeKey'


### PR DESCRIPTION
In the previous implementation, a map conversion was done to ensure that the `defaultActiveKey` was string array, resulting in a dead loop where each passed in dependency was a new array.
This now seems unnecessary as the`key` is restricted to string and no one would pass a number specifically via an expression, and sunmao itself has a type check hint.
So on balance, it was decided to remove this conversion

