### PR TITLE
expose services when init editor

### DIFF
--- a/packages/editor/src/init.tsx
+++ b/packages/editor/src/init.tsx
@@ -152,5 +152,6 @@ export function initSunmaoUIEditor(props: SunmaoUIEditorProps = {}) {
   return {
     Editor,
     registry,
+    services,
   };
 }


### PR DESCRIPTION
integration users can get services after `initSunmaoUIEditor`, then they can call things like `apiService` to implement other features.