### PR TITLE
feat(editor): hide warning area & disable validator

### DIFF
--- a/packages/editor/src/components/WarningArea/ErrorLogs.tsx
+++ b/packages/editor/src/components/WarningArea/ErrorLogs.tsx
@@ -4,7 +4,7 @@ import { DebugTable } from './Table';
 import { Box } from '@chakra-ui/react';
 
 export const ErrorLogs: React.FC<Props> = ({ services }) => {
-  const { validateResult, setSelectedComponentId } = services.editorStore;
+  const { setSelectedComponentId } = services.editorStore;
   const errorColumns = [
     {
       title: 'Component Id',
@@ -37,7 +37,7 @@ export const ErrorLogs: React.FC<Props> = ({ services }) => {
 
   return (
     <DebugTable
-      data={validateResult}
+      data={[]}
       pagination={{ hideOnSinglePage: true }}
       columns={errorColumns}
       emptyMessage="No Errors"

--- a/packages/editor/src/components/WarningArea/WarningArea.tsx
+++ b/packages/editor/src/components/WarningArea/WarningArea.tsx
@@ -5,7 +5,6 @@ import {
   HStack,
   IconButton,
   Tabs,
-  Text,
   TabPanel,
   TabPanels,
   TabList,
@@ -150,14 +149,6 @@ export const WarningArea: React.FC<Props> = observer(({ services }) => {
       >
         <Tabs h="full" w="full" variant="soft-rounded" colorScheme="gray">
           <TabList>
-            <Tab alignItems="baseline">
-              <Text fontSize="md" fontWeight="bold">
-                Errors
-              </Text>
-              <Badge ml="1" fontSize="0.8em" colorScheme="red">
-                {editorStore.validateResult.length}
-              </Badge>
-            </Tab>
             <Tab>Logs</Tab>
             <HStack w="full" justify="end">
               {editorStore.isSaved ? savedBadge : unsaveBadge}

--- a/packages/editor/src/init.tsx
+++ b/packages/editor/src/init.tsx
@@ -92,13 +92,7 @@ export function initSunmaoUIEditor(props: SunmaoUIEditorProps = {}) {
     appStorage.app.spec.components
   );
   const widgetManager = new WidgetManager();
-  const editorStore = new EditorStore(
-    eventBus,
-    registry,
-    stateManager,
-    appStorage,
-    appModelManager
-  );
+  const editorStore = new EditorStore(eventBus, registry, stateManager, appStorage);
   editorStore.eleMap = ui.eleMap;
 
   const services = {


### PR DESCRIPTION
In the current development, the validator has not played the expected role because there are always hundreds of errors, and the large number of errors makes it meaningless. This is because the current component type definition is not very complete, and most of the errors are actually expected.
Therefore, we have temporarily disabled the validator in the editor to save performance. If the component type definition is improved in the future, Validator can be added to the project's CI as part of unit testing.


<img width="1186" alt="截屏2023-08-28 下午4 38 25" src="https://github.com/smartxworks/sunmao-ui/assets/12260952/53fa7f85-131b-4e33-8406-075d327a3867">
