### PR TITLE
fix: the data passed to shouldRender should be evaled

### DIFF
--- a/packages/editor-sdk/src/components/Widgets/CategoryWidget.tsx
+++ b/packages/editor-sdk/src/components/Widgets/CategoryWidget.tsx
@@ -97,7 +97,10 @@ export const CategoryWidget: React.FC<WidgetProps<CategoryWidgetType>> = props =
             if (typeof propertySpec === 'boolean') {
               return null;
             }
-            return shouldRender(propertySpec.conditions || [], value) ? (
+            return shouldRender(
+              propertySpec.conditions || [],
+              services.stateManager.deepEval(value)
+            ) ? (
               <SpecWidget
                 key={name}
                 component={component}

--- a/packages/editor-sdk/src/components/Widgets/ObjectField.tsx
+++ b/packages/editor-sdk/src/components/Widgets/ObjectField.tsx
@@ -35,7 +35,10 @@ export const ObjectField: React.FC<WidgetProps<ObjectFieldType>> = props => {
           return null;
         }
 
-        return shouldRender(subSpec.conditions || [], value) ? (
+        return shouldRender(
+          subSpec.conditions || [],
+          services.stateManager.deepEval(value)
+        ) ? (
           <SpecWidget
             component={component}
             key={name + component.id}


### PR DESCRIPTION
The data passed to `shouldRender` function should first undergo an eval computation to identify the content of the expression,so that conditions can work     
      
![test-expression-conditions](https://github.com/smartxworks/sunmao-ui/assets/96771399/75f702c1-b702-495a-a48a-e47673d0054e)
