### PR TITLE
feat(runtime): add watcher data source

### DIFF
--- a/packages/runtime/src/components/core/Watcher.ts
+++ b/packages/runtime/src/components/core/Watcher.ts
@@ -1,0 +1,42 @@
+import { Type } from '@sinclair/typebox';
+import {
+  CORE_VERSION_V2,
+  CoreComponentName,
+  PRESET_PROPERTY_CATEGORY,
+} from '@sunmao-ui/shared';
+import { implementRuntimeComponent } from '../../utils/buildKit';
+import { useEffect } from 'react';
+
+export default implementRuntimeComponent({
+  version: CORE_VERSION_V2,
+  metadata: {
+    name: CoreComponentName.Watcher,
+    displayName: 'Watcher',
+    description: 'Watch expression changing and trigger events',
+    exampleProperties: { value: '' },
+    isDataSource: true,
+    annotations: {
+      category: 'Data',
+    },
+  },
+  spec: {
+    properties: Type.Object({
+      value: Type.String({
+        title: 'Value',
+        category: PRESET_PROPERTY_CATEGORY.Basic,
+      }),
+    }),
+    state: Type.Object({ value: Type.Any() }),
+    methods: {},
+    slots: {},
+    styleSlots: [],
+    events: ['onChange'],
+  },
+})(({ value, mergeState, callbackMap }) => {
+  useEffect(() => {
+    mergeState({ value });
+    callbackMap?.onChange();
+  }, [callbackMap, mergeState, value]);
+
+  return null;
+});

--- a/packages/runtime/src/services/Registry.tsx
+++ b/packages/runtime/src/services/Registry.tsx
@@ -11,6 +11,7 @@ import CoreStack from '../components/core/Stack';
 import CoreFileInput from '../components/core/FileInput';
 import CoreList from '../components/core/List';
 import CoreIframe from '../components/core/Iframe';
+import CoreWatcher from '../components/core/Watcher';
 
 // traits
 import CoreArrayState from '../traits/core/ArrayState';
@@ -257,6 +258,7 @@ export function initRegistry(
   registry.registerComponent(CoreFileInput);
   registry.registerComponent(CoreList);
   registry.registerComponent(CoreIframe);
+  registry.registerComponent(CoreWatcher);
 
   registry.registerTrait(CoreState);
   registry.registerTrait(CoreArrayState);

--- a/packages/shared/src/constants/core.ts
+++ b/packages/shared/src/constants/core.ts
@@ -7,6 +7,7 @@ export enum CoreComponentName {
   ModuleContainer = 'moduleContainer',
   Text = 'text',
   Iframe = 'iframe',
+  Watcher = 'watcher',
 }
 // core traits
 export enum CoreTraitName {


### PR DESCRIPTION
Add a `watcher` data source, to watch expression changes, and trigger events.
With this data source, developer don't have to add `onChange` event for every component's state. It is also very useful to complicated expression.

The usage is like:
<img width="347" alt="截屏2023-08-30 下午4 44 22" src="https://github.com/smartxworks/sunmao-ui/assets/12260952/8a74729b-76c3-4a68-b31b-dcfafb9db634">

**Note that the `exp` property requires a string in expression format without `{{}}`.** This is to prevent the `exp` being evaled when compiling template.
