### PR TITLE
fix: remove the useless component key

### DIFF
--- a/packages/runtime/src/components/_internal/ImplWrapper/ImplWrapperMain.tsx
+++ b/packages/runtime/src/components/_internal/ImplWrapper/ImplWrapperMain.tsx
@@ -172,7 +172,6 @@ export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps
       <Impl
         data-sunmao-id={c.id}
         ref={ref}
-        key={c.id}
         {...omit(props, ['slotContext'])}
         {...mergedProps}
         slotsElements={slotElements}
@@ -185,7 +184,6 @@ export const ImplWrapperMain = React.forwardRef<HTMLDivElement, ImplWrapperProps
 
     return (
       <ComponentErrorBoundary
-        key={c.id}
         componentId={c.id}
         onRef={onRef}
         onRecoverFromError={onRecoverFromError}


### PR DESCRIPTION
These components are not in the iteration, so we don't need to add a key. Additionally, if the component ID is dynamic and has an index variable, the component will re-generate when the id is changed.

Based on the above points, we should remove the useless component key.